### PR TITLE
feat: set inherited permissions for updated files

### DIFF
--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -351,9 +351,9 @@ bool FileUpdater::reset_rights(const fs::path& path)
 	ACL empty_acl;
 	if (InitializeAcl(&empty_acl, sizeof(empty_acl), ACL_REVISION))
 	{
-		DWORD result = SetNamedSecurityInfo((LPWSTR)path.c_str(), SE_FILE_OBJECT, 
-											DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION, 
-											0, 0, &empty_acl, 0);
+        DWORD result = SetNamedSecurityInfo((LPWSTR)path.c_str(), SE_FILE_OBJECT, 
+                                            DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION, 
+                                            0, 0, &empty_acl, 0);
 		if (result == ERROR_SUCCESS)
 		{
 			return true;

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -349,13 +349,15 @@ void FileUpdater::update()
 bool FileUpdater::reset_rights(const fs::path& path)
 {
 	ACL empty_acl;
-	if (InitializeAcl(&empty_acl, sizeof(empty_acl), ACL_REVISION)) 
+	if (InitializeAcl(&empty_acl, sizeof(empty_acl), ACL_REVISION))
 	{
-		DWORD result = SetNamedSecurityInfo((LPWSTR)path.c_str() ,SE_FILE_OBJECT, DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION, 0, 0, &empty_acl, 0  );
-		if(result == ERROR_SUCCESS)
+		DWORD result = SetNamedSecurityInfo((LPWSTR)path.c_str(), SE_FILE_OBJECT, 
+											DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION, 
+											0, 0, &empty_acl, 0);
+		if (result == ERROR_SUCCESS)
 		{
 			return true;
-		} 
+		}
 	}
 	return false;
 }

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -351,9 +351,9 @@ bool FileUpdater::reset_rights(const fs::path& path)
 	ACL empty_acl;
 	if (InitializeAcl(&empty_acl, sizeof(empty_acl), ACL_REVISION))
 	{
-        DWORD result = SetNamedSecurityInfo((LPWSTR)path.c_str(), SE_FILE_OBJECT, 
-                                            DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION, 
-                                            0, 0, &empty_acl, 0);
+		DWORD result = SetNamedSecurityInfo((LPWSTR)path.c_str(), SE_FILE_OBJECT,
+			DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION,
+			0, 0, &empty_acl, 0);
 		if (result == ERROR_SUCCESS)
 		{
 			return true;


### PR DESCRIPTION
Reset files rights to default(inherited ) after moving files from temp folder to SLOBS folder. 

Errors ignored as it is not a primary functionality of updater and errors expected for fat filesystem. 