### PR TITLE
Extra check if files integrity on revert

### DIFF
--- a/src/file-updater.cc
+++ b/src/file-updater.cc
@@ -159,7 +159,7 @@ bool FileUpdater::backup()
 {
 	for (manifest_map_t::const_iterator iter = m_manifest.begin(); iter != m_manifest.end(); ++iter) {
 		try {
-			if (iter->second.skip_update)
+			if (iter->second.skip_update || !iter->second.compared_to_local) 
 				continue;
 
 			std::error_code ec;
@@ -181,6 +181,9 @@ bool FileUpdater::backup()
 					wlog_debug(L"Failed to backup entry %s to %s, error %s", to_path.c_str(), old_file_path.c_str(), wmsg.c_str());
 					return false;
 				}
+			} else {
+				wlog_error(L"File selected for update %s does not exist anymore, backup not possible", to_path.c_str());
+				return false;
 			}
 		} catch (...) {
 			return false;

--- a/src/file-updater.cc
+++ b/src/file-updater.cc
@@ -189,3 +189,15 @@ bool FileUpdater::backup()
 
 	return true;
 }
+
+bool FileUpdater::verify(std::vector<std::pair<fs::path, std::string>> &local_files) 
+{
+	for (auto &file : local_files) {
+		std::string checksum = calculate_files_checksum_safe(file.first);
+		if (checksum != file.second) {
+			wlog_error(L"File %s checksum mismatch, expected %s, now %s", file.first.c_str(), file.second.c_str(), checksum.c_str());
+			return false;
+		}
+	}
+	return true;
+}

--- a/src/file-updater.cc
+++ b/src/file-updater.cc
@@ -150,7 +150,7 @@ void FileUpdater::revert()
 		}
 	}
 
-	if (error_count > 0 || !is_local_files_changed()) {
+	if (error_count > 0 || is_local_files_changed()) {
 		wlog_warn(L"Revert have failed to correctly revert some files. Fails: %i", error_count);
 		throw std::exception("Revert have failed to correctly revert some files");
 	}
@@ -200,10 +200,10 @@ bool FileUpdater::is_local_files_changed()
 		std::string checksum = calculate_files_checksum_safe(file.first);
 		if (checksum != file.second) {
 			wlog_error(L"File %s checksum mismatch after revert, expected %s, now %s", file.first.c_str(), file.second.c_str(), checksum.c_str());
-			return false;
+			return true;
 		}
 	}
 
 	log_info("Check of files checksums after revert: passed.");
-	return true;
+	return false;
 }

--- a/src/file-updater.h
+++ b/src/file-updater.h
@@ -14,20 +14,24 @@ struct FileUpdater {
 	FileUpdater &operator=(const FileUpdater &) = delete;
 	FileUpdater &operator=(FileUpdater &&) = delete;
 
-	explicit FileUpdater(fs::path old_files_dir, fs::path app_dir, fs::path new_files_dir, const manifest_map_t &manifest);
+	explicit FileUpdater(fs::path old_files_dir, fs::path app_dir, fs::path new_files_dir, const manifest_map_t &manifest,
+			     const local_manifest_t &local_manifest);
 	~FileUpdater();
 
 	void update();
-	bool update_entry(manifest_map_t::const_iterator &iter, fs::path &new_files_dir);
-	bool update_entry_with_retries(manifest_map_t::const_iterator &iter, fs::path &new_files_dir);
 	void revert();
-	bool reset_rights(const fs::path &path);
 	bool backup();
-	bool verify(std::vector<std::pair<fs::path, std::string>> &local_files);
 
 private:
+	bool update_entry(manifest_map_t::const_iterator &iter, fs::path &new_files_dir);
+	bool update_entry_with_retries(manifest_map_t::const_iterator &iter, fs::path &new_files_dir);
+	bool reset_rights(const fs::path &path);
+	bool is_local_files_changed();
+
 	fs::path m_old_files_dir;
 	fs::path m_app_dir;
 	fs::path m_new_files_dir;
+
 	const manifest_map_t &m_manifest;
+	const local_manifest_t &m_local_manifest;
 };

--- a/src/file-updater.h
+++ b/src/file-updater.h
@@ -23,6 +23,7 @@ struct FileUpdater {
 	void revert();
 	bool reset_rights(const fs::path &path);
 	bool backup();
+	bool verify(std::vector<std::pair<fs::path, std::string>> &local_files);
 
 private:
 	fs::path m_old_files_dir;

--- a/src/file-updater.h
+++ b/src/file-updater.h
@@ -27,6 +27,7 @@ private:
 	bool update_entry_with_retries(manifest_map_t::const_iterator &iter, fs::path &new_files_dir);
 	bool reset_rights(const fs::path &path);
 	bool is_local_files_changed();
+	bool is_local_files_updated();
 
 	fs::path m_old_files_dir;
 	fs::path m_app_dir;

--- a/src/update-client-internal.hpp
+++ b/src/update-client-internal.hpp
@@ -80,6 +80,7 @@ struct update_client {
 	std::atomic_size_t active_pids{0};
 	std::list<update_client::pid *> pids_waiters;
 
+	std::vector<std::pair<fs::path, std::string>> local_files;
 	manifest_map_t manifest;
 	std::mutex manifest_mutex;
 	manifest_map_t::const_iterator manifest_iterator;
@@ -123,7 +124,7 @@ public:
 	void handle_resolve(const boost::system::error_code &error, resolver_type::results_type results);
 	void handle_manifest_result(manifest_request<manifest_body> *request_ctx);
 	void process_manifest_results();
-	void checkup_files(struct blockers_map_t &blockers, std::vector<fs::path> files, int from, int to);
+	void checkup_files(struct blockers_map_t &blockers, int from, int to);
 	void checkup_manifest(struct blockers_map_t &blockers);
 
 	//files

--- a/src/update-client-internal.hpp
+++ b/src/update-client-internal.hpp
@@ -80,7 +80,7 @@ struct update_client {
 	std::atomic_size_t active_pids{0};
 	std::list<update_client::pid *> pids_waiters;
 
-	std::vector<std::pair<fs::path, std::string>> local_files;
+	local_manifest_t local_manifest;
 	manifest_map_t manifest;
 	std::mutex manifest_mutex;
 	manifest_map_t::const_iterator manifest_iterator;

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -82,8 +82,14 @@ void update_client::start_file_update()
 		log_info("Going to revert.");
 		try {
 			updater.revert();
-			reverted = true;
 			log_info("Revert completed.");
+
+			if (updater.verify(local_files)) {
+				log_info("Check of files checksums after revert: passed.");
+				reverted = true;
+			} else {
+				log_info("Check of files checksums after revert: failed.");
+			}
 		} catch (std::exception &e) {
 			log_error("Revert failed: %s.", e.what());
 		} catch (...) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -153,8 +153,8 @@ BOOL StartApplication(LPWSTR lpCommandLine, LPCWSTR lpWorkingDirectory)
 		return FALSE;
 	}
 
-	bSuccess = DuplicateTokenEx(hShellToken, TOKEN_QUERY | TOKEN_ASSIGN_PRIMARY | TOKEN_DUPLICATE | TOKEN_ADJUST_DEFAULT | TOKEN_ADJUST_SESSIONID, NULL, SecurityImpersonation,
-				    TokenPrimary, &hNewToken);
+	bSuccess = DuplicateTokenEx(hShellToken, TOKEN_QUERY | TOKEN_ASSIGN_PRIMARY | TOKEN_DUPLICATE | TOKEN_ADJUST_DEFAULT | TOKEN_ADJUST_SESSIONID, NULL,
+				    SecurityImpersonation, TokenPrimary, &hNewToken);
 
 	if (bSuccess == 0) {
 		LogLastError(L"DuplicateTokenEx");
@@ -276,7 +276,7 @@ std::string unfixup_uri(const std::string &source)
 	return result;
 }
 
-std::string calculate_files_checksum_safe(fs::path &path)
+std::string calculate_files_checksum_safe(const fs::path &path)
 {
 	std::string checksum = "";
 	try {
@@ -289,7 +289,7 @@ std::string calculate_files_checksum_safe(fs::path &path)
 	return checksum;
 }
 
-std::string calculate_files_checksum(fs::path &path)
+std::string calculate_files_checksum(const fs::path &path)
 {
 	std::ostringstream hex_digest;
 	unsigned char hash[SHA256_DIGEST_LENGTH] = {0};
@@ -325,38 +325,19 @@ std::string calculate_files_checksum(fs::path &path)
 	return hex_digest.str();
 }
 
-
-std::vector<char> get_messages_callback( std::string const &file_name, std::string const &encoding )
+std::vector<char> get_messages_callback(std::string const &file_name, std::string const &encoding)
 {
-	static std::unordered_map<std::string, int> locales_resources ({
-		{ "/ar_SA/LC_MESSAGES/messages.mo", 101 },
-		{ "/cs_CZ/LC_MESSAGES/messages.mo", 102 },
-		{ "/da_DK/LC_MESSAGES/messages.mo", 103 },
-		{ "/de_DE/LC_MESSAGES/messages.mo", 104 },
-		{ "/en_US/LC_MESSAGES/messages.mo", 105 },
-		{ "/es_ES/LC_MESSAGES/messages.mo", 106 },
-		{ "/fr_FR/LC_MESSAGES/messages.mo", 107 },
-		{ "/hu_HU/LC_MESSAGES/messages.mo", 108 },
-		{ "/id_ID/LC_MESSAGES/messages.mo", 109 },
-		{ "/it_IT/LC_MESSAGES/messages.mo", 110 },
-		{ "/ja_JP/LC_MESSAGES/messages.mo", 111 },
-		{ "/ko_KR/LC_MESSAGES/messages.mo", 112 },
-		{ "/mk_MK/LC_MESSAGES/messages.mo", 113 },
-		{ "/nl_NL/LC_MESSAGES/messages.mo", 114 },
-		{ "/pl_PL/LC_MESSAGES/messages.mo", 115 },
-		{ "/pt_BR/LC_MESSAGES/messages.mo", 116 },
-		{ "/pt_PT/LC_MESSAGES/messages.mo", 117 },
-		{ "/ru_RU/LC_MESSAGES/messages.mo", 118 },
-		{ "/sk_SK/LC_MESSAGES/messages.mo", 119 },
-		{ "/sl_SI/LC_MESSAGES/messages.mo", 120 },
-		{ "/sv_SE/LC_MESSAGES/messages.mo", 121 },
-		{ "/th_TH/LC_MESSAGES/messages.mo", 122 },
-		{ "/tr_TR/LC_MESSAGES/messages.mo", 123 },
-		{ "/vi_VN/LC_MESSAGES/messages.mo", 124 },
-		{ "/zh_CN/LC_MESSAGES/messages.mo", 125 },
-		{ "/zh_TW/LC_MESSAGES/messages.mo", 126 }
-	});
-	std::vector <char> localization;
+	static std::unordered_map<std::string, int> locales_resources(
+		{{"/ar_SA/LC_MESSAGES/messages.mo", 101}, {"/cs_CZ/LC_MESSAGES/messages.mo", 102}, {"/da_DK/LC_MESSAGES/messages.mo", 103},
+		 {"/de_DE/LC_MESSAGES/messages.mo", 104}, {"/en_US/LC_MESSAGES/messages.mo", 105}, {"/es_ES/LC_MESSAGES/messages.mo", 106},
+		 {"/fr_FR/LC_MESSAGES/messages.mo", 107}, {"/hu_HU/LC_MESSAGES/messages.mo", 108}, {"/id_ID/LC_MESSAGES/messages.mo", 109},
+		 {"/it_IT/LC_MESSAGES/messages.mo", 110}, {"/ja_JP/LC_MESSAGES/messages.mo", 111}, {"/ko_KR/LC_MESSAGES/messages.mo", 112},
+		 {"/mk_MK/LC_MESSAGES/messages.mo", 113}, {"/nl_NL/LC_MESSAGES/messages.mo", 114}, {"/pl_PL/LC_MESSAGES/messages.mo", 115},
+		 {"/pt_BR/LC_MESSAGES/messages.mo", 116}, {"/pt_PT/LC_MESSAGES/messages.mo", 117}, {"/ru_RU/LC_MESSAGES/messages.mo", 118},
+		 {"/sk_SK/LC_MESSAGES/messages.mo", 119}, {"/sl_SI/LC_MESSAGES/messages.mo", 120}, {"/sv_SE/LC_MESSAGES/messages.mo", 121},
+		 {"/th_TH/LC_MESSAGES/messages.mo", 122}, {"/tr_TR/LC_MESSAGES/messages.mo", 123}, {"/vi_VN/LC_MESSAGES/messages.mo", 124},
+		 {"/zh_CN/LC_MESSAGES/messages.mo", 125}, {"/zh_TW/LC_MESSAGES/messages.mo", 126}});
+	std::vector<char> localization;
 
 	HMODULE hmodule = GetModuleHandle(NULL);
 	if (hmodule) {
@@ -384,28 +365,27 @@ std::vector<char> get_messages_callback( std::string const &file_name, std::stri
 
 void setup_locale()
 {
-	const char * current_locale = std::setlocale(LC_ALL, nullptr);
-	if (current_locale == nullptr || std::strlen(current_locale) == 0)
-	{
+	const char *current_locale = std::setlocale(LC_ALL, nullptr);
+	if (current_locale == nullptr || std::strlen(current_locale) == 0) {
 		std::setlocale(LC_ALL, "en_US.UTF-8");
 	}
 
 	namespace blg = boost::locale::gnu_gettext;
 	blg::messages_info info;
 
-	info.paths.push_back(""); 
+	info.paths.push_back("");
 	info.domains.push_back(blg::messages_info::domain("messages"));
 	info.callback = get_messages_callback;
-	
+
 	boost::locale::generator gen;
 	std::locale base_locale = gen("");
 
 	boost::locale::info const &properties = std::use_facet<boost::locale::info>(base_locale);
 	info.language = properties.language();
-	info.country  = properties.country();
+	info.country = properties.country();
 	info.encoding = properties.encoding();
-	info.variant  = properties.variant();
+	info.variant = properties.variant();
 
-	std::locale real_locale(base_locale,blg::create_messages_facet<char>(info));
+	std::locale real_locale(base_locale, blg::create_messages_facet<char>(info));
 	std::locale::global(real_locale);
 }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <sstream>
 
+#include <boost/exception/all.hpp>
+
 #include "logger/log.h"
 #include "checksum-filters.hpp"
 #include <boost/algorithm/string/replace.hpp>
@@ -272,6 +274,19 @@ std::string unfixup_uri(const std::string &source)
 	boost::algorithm::replace_all(result, "%20", " ");
 
 	return result;
+}
+
+std::string calculate_files_checksum_safe(fs::path &path)
+{
+	std::string checksum = "";
+	try {
+		checksum = calculate_files_checksum(path);
+	} catch (const boost::exception &e) {
+		log_warn("Failed to calculate checksum of local file. Try to update it. Exception: %s", boost::diagnostic_information(e).c_str());
+	} catch (const std::exception &e) {
+		log_warn("Failed to calculate checksum of local file. Try to update it. std::exception: %s", e.what());
+	}
+	return checksum;
 }
 
 std::string calculate_files_checksum(fs::path &path)

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -327,16 +327,34 @@ std::string calculate_files_checksum(const fs::path &path)
 
 std::vector<char> get_messages_callback(std::string const &file_name, std::string const &encoding)
 {
-	static std::unordered_map<std::string, int> locales_resources(
-		{{"/ar_SA/LC_MESSAGES/messages.mo", 101}, {"/cs_CZ/LC_MESSAGES/messages.mo", 102}, {"/da_DK/LC_MESSAGES/messages.mo", 103},
-		 {"/de_DE/LC_MESSAGES/messages.mo", 104}, {"/en_US/LC_MESSAGES/messages.mo", 105}, {"/es_ES/LC_MESSAGES/messages.mo", 106},
-		 {"/fr_FR/LC_MESSAGES/messages.mo", 107}, {"/hu_HU/LC_MESSAGES/messages.mo", 108}, {"/id_ID/LC_MESSAGES/messages.mo", 109},
-		 {"/it_IT/LC_MESSAGES/messages.mo", 110}, {"/ja_JP/LC_MESSAGES/messages.mo", 111}, {"/ko_KR/LC_MESSAGES/messages.mo", 112},
-		 {"/mk_MK/LC_MESSAGES/messages.mo", 113}, {"/nl_NL/LC_MESSAGES/messages.mo", 114}, {"/pl_PL/LC_MESSAGES/messages.mo", 115},
-		 {"/pt_BR/LC_MESSAGES/messages.mo", 116}, {"/pt_PT/LC_MESSAGES/messages.mo", 117}, {"/ru_RU/LC_MESSAGES/messages.mo", 118},
-		 {"/sk_SK/LC_MESSAGES/messages.mo", 119}, {"/sl_SI/LC_MESSAGES/messages.mo", 120}, {"/sv_SE/LC_MESSAGES/messages.mo", 121},
-		 {"/th_TH/LC_MESSAGES/messages.mo", 122}, {"/tr_TR/LC_MESSAGES/messages.mo", 123}, {"/vi_VN/LC_MESSAGES/messages.mo", 124},
-		 {"/zh_CN/LC_MESSAGES/messages.mo", 125}, {"/zh_TW/LC_MESSAGES/messages.mo", 126}});
+	static std::unordered_map<std::string, int> locales_resources({
+		{ "/ar_SA/LC_MESSAGES/messages.mo", 101 },
+		{ "/cs_CZ/LC_MESSAGES/messages.mo", 102 },
+		{ "/da_DK/LC_MESSAGES/messages.mo", 103 },
+		{ "/de_DE/LC_MESSAGES/messages.mo", 104 },
+		{ "/en_US/LC_MESSAGES/messages.mo", 105 },
+		{ "/es_ES/LC_MESSAGES/messages.mo", 106 },
+		{ "/fr_FR/LC_MESSAGES/messages.mo", 107 },
+		{ "/hu_HU/LC_MESSAGES/messages.mo", 108 },
+		{ "/id_ID/LC_MESSAGES/messages.mo", 109 },
+		{ "/it_IT/LC_MESSAGES/messages.mo", 110 },
+		{ "/ja_JP/LC_MESSAGES/messages.mo", 111 },
+		{ "/ko_KR/LC_MESSAGES/messages.mo", 112 },
+		{ "/mk_MK/LC_MESSAGES/messages.mo", 113 },
+		{ "/nl_NL/LC_MESSAGES/messages.mo", 114 },
+		{ "/pl_PL/LC_MESSAGES/messages.mo", 115 },
+		{ "/pt_BR/LC_MESSAGES/messages.mo", 116 },
+		{ "/pt_PT/LC_MESSAGES/messages.mo", 117 },
+		{ "/ru_RU/LC_MESSAGES/messages.mo", 118 },
+		{ "/sk_SK/LC_MESSAGES/messages.mo", 119 },
+		{ "/sl_SI/LC_MESSAGES/messages.mo", 120 },
+		{ "/sv_SE/LC_MESSAGES/messages.mo", 121 },
+		{ "/th_TH/LC_MESSAGES/messages.mo", 122 },
+		{ "/tr_TR/LC_MESSAGES/messages.mo", 123 },
+		{ "/vi_VN/LC_MESSAGES/messages.mo", 124 },
+		{ "/zh_CN/LC_MESSAGES/messages.mo", 125 },
+		{ "/zh_TW/LC_MESSAGES/messages.mo", 126 }
+	});
 	std::vector<char> localization;
 
 	HMODULE hmodule = GetModuleHandle(NULL);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -43,6 +43,7 @@ std::string encimpl(std::string::value_type v);
 std::string urlencode(const std::string &url);
 
 std::string calculate_files_checksum(fs::path &path);
+std::string calculate_files_checksum_safe(fs::path &path);
 
 void setup_locale();
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -42,8 +42,8 @@ std::string fixup_uri(const std::string &source);
 std::string encimpl(std::string::value_type v);
 std::string urlencode(const std::string &url);
 
-std::string calculate_files_checksum(fs::path &path);
-std::string calculate_files_checksum_safe(fs::path &path);
+std::string calculate_files_checksum(const fs::path &path);
+std::string calculate_files_checksum_safe(const fs::path &path);
 
 void setup_locale();
 
@@ -80,3 +80,4 @@ struct manifest_entry_t {
 };
 
 using manifest_map_t = std::unordered_map<std::string, manifest_entry_t>;
+using local_manifest_t = std::vector<std::pair<fs::path, std::string>>;

--- a/test/src/generate_files.js
+++ b/test/src/generate_files.js
@@ -407,6 +407,8 @@ exports.generate_test_files = async function (testinfo) {
     await generate_result_dir(testinfo, testinfo.resultDir);
   if (testinfo.expectedResult == "filesnotchanged")
     await generate_initial_dir(testinfo, testinfo.resultDir);
+  if (testinfo.expectedResult == "filescorrupted")
+    await generate_initial_dir(testinfo, testinfo.resultDir);
 
 }
 

--- a/test/src/run_test.js
+++ b/test/src/run_test.js
@@ -32,8 +32,9 @@ exports.test_update = async function (testinfo) {
   try {
     let launched = await updater_launcher.start_updater(testinfo)
     let ret = 0;
-
-    if (!generate_files.check_results(testinfo)) {
+    if (testinfo.expectedResult == "filescorrupted") { 
+      console.log("=== Test " + testinfo.number + " result: after updater files corrupted as expected");
+    } else if (!generate_files.check_results(testinfo)) {
       ret = 1;
       console.log("=== Test " + testinfo.number + " result: after updater files not as expected");
     } else {

--- a/test/src/run_tests.js
+++ b/test/src/run_tests.js
@@ -21,26 +21,27 @@ async function run_tests() {
         //testinfo.serverUrl = "https://outlook.live.com";
         //testinfo.let_15sec = true;
         //testinfo.let_block_one_file = true;
+        //testinfo.let_404 = true;
         //testinfo.morebigfiles = true;
-        //testinfo.expectedResult = "filesnotchanged"
+        testinfo.expectedResult = "filescorrupted"
         // testinfo.selfBlockersCount = 5;
         // testinfo.selfBlockingFile = true;
         // testinfo.selfLockingFile = true;
-        testinfo.systemFolder = true;
+        //testinfo.systemFolder = true;
         testinfo.runAsInteractive = 1;
         //testinfo.wrong_arguments = true;
         //testinfo.expectedResult = "filesnotchanged"
         //testinfo.manifestGenerated = false;
         //testinfo.let_5sec = true;
-        testinfo.morebigfiles = true;
+        //testinfo.morebigfiles = true;
+        testinfo.corruptBackuped = true;
         //testinfo.selfBlockersCount = 5;
-        //testinfo.selfBlockingFile = true;
         //testinfo.pidWaiting = true;
         //testinfo.selfBlockingFile = true;
         //testinfo.let_drop = true;
         //testinfo.let_404 = true;
         //testinfo.max_trouble = 500;
-        //testinfo.expected_change_for_trouble = 50;
+        //testinfo.expected_chance_for_trouble = 50;
         //testinfo.serverStarted = false;
         //testinfo.let_block_manifest = true;
         //testinfo.more_log_output = true;
@@ -110,7 +111,7 @@ async function run_tests() {
         testinfo = test_config.gettestinfo(" //test server to fail on all bad nodes with to many faild downloads ");
         testinfo.let_404 = true;
         testinfo.max_trouble = 100;
-        testinfo.expected_change_for_trouble = 55;
+        testinfo.expected_chance_for_trouble = 55;
         testinfo.morebigfiles = true;
         testinfo.expectedResult = "filesnotchanged"
         test_result = await run_test.test_update(testinfo);
@@ -208,6 +209,14 @@ async function run_tests() {
         testinfo.expectedResult = "filesnotchanged"
         testinfo.systemFolder = true;
         test_result = await run_test.test_update(testinfo);
+        if (test_result != 0) {
+            failed_test_names.push(testinfo.testName);
+        }
+
+        testinfo = test_config.gettestinfo(" //failed to revert of failed update ");
+        test_result = await run_test.test_update(testinfo);
+        testinfo.corruptBackuped = true;
+        testinfo.expectedResult = "filescorrupted"
         if (test_result != 0) {
             failed_test_names.push(testinfo.testName);
         }

--- a/test/src/run_tests.js
+++ b/test/src/run_tests.js
@@ -34,7 +34,7 @@ async function run_tests() {
         //testinfo.manifestGenerated = false;
         //testinfo.let_5sec = true;
         //testinfo.morebigfiles = true;
-        testinfo.corruptBackuped = true;
+        //testinfo.corruptBackuped = true;
         //testinfo.selfBlockersCount = 5;
         //testinfo.pidWaiting = true;
         //testinfo.selfBlockingFile = true;

--- a/test/src/test_config.js
+++ b/test/src/test_config.js
@@ -78,9 +78,6 @@ exports.gettestinfo = function (testname) {
 
   newinfo.updaterDir = path.join(__dirname, "..", "..", "build", "distribute","a-file-updater")
   newinfo.updaterWorkDir = path.join(testfilesDir, "updaİeł")
-  newinfo.updateCfg = path.join(os.tmpdir(), 'slobs-updater', 'update.cfg');
-  newinfo.updateCfgBak = path.join(os.tmpdir(), 'slobs-updater', 'update.cfg.last');
-
 
   newinfo.files = [
     { name: "filech1.jpeg", hugefile: false, testing: "changed content" },

--- a/test/src/test_config.js
+++ b/test/src/test_config.js
@@ -40,12 +40,13 @@ exports.gettestinfo = function (testname) {
     let_5sec: false,
     let_15sec: false,
     max_trouble: 20,
-    expected_change_for_trouble: 90,
+    expected_chance_for_trouble: 90,
     let_block_manifest: false,
     let_block_one_file: false,
     block_file_number: 10,
     wrong_arguments: false,
     systemFolder: false,
+    corruptBackuped: false,
 
     //sentry emulator
     reporterHost: "localhost",
@@ -56,7 +57,7 @@ exports.gettestinfo = function (testname) {
     runAsInteractive: '0',
 
     //test results 
-    expectedResult: "filesupdated", // "filesnotchanged", ""
+    expectedResult: "filesupdated", // "filesnotchanged", "", "filescorrupted"
     expectedCrashReport: false,
 
     register_unnecesary_request: false,
@@ -82,6 +83,8 @@ exports.gettestinfo = function (testname) {
 
 
   newinfo.files = [
+    { name: "filech1.jpeg", hugefile: false, testing: "changed content" },
+    { name: "filech2.jpeg", hugefile: false, testing: "changed content" },
     { name: "filea.exe", hugefile: false, testing: "deleted empty" },
     { name: "file1.exe", hugefile: false, testing: "deleted" },
     { name: "file2.txt", hugefile: false, testing: "deleted" },


### PR DESCRIPTION
Use checksum to check if installation folder in an expected state. 

After update it expected to have new files with checksums from manifest. 
If update failed and there was an attempt to revert. Then files should have same checksums what they had before update started. 
If checksum mismatch detected updater will show a message to a user. 

There is a new test for failed revert use case. 