### PR TITLE
Fix duplicates in a list of apps blocking files

### DIFF
--- a/src/blocker-panel.cc
+++ b/src/blocker-panel.cc
@@ -5,6 +5,7 @@
 #include <shellapi.h>
 #include <windowsx.h>
 #include <commctrl.h>
+#include <tlhelp32.h>
 
 #pragma comment(lib, "Shell32.lib")
 
@@ -252,31 +253,84 @@ LRESULT blocker_panel::handle_custom_draw(LPNMLVCUSTOMDRAW lvcd)
 	return CDRF_DODEFAULT;
 }
 
-struct enum_wnd_data {
-	DWORD target_pid;
+struct enum_best_wnd_data {
+	std::vector<DWORD> pids;
 	HWND result;
+	int best_area;
 };
 
-static BOOL CALLBACK find_main_window_cb(HWND hwnd, LPARAM lParam)
+static BOOL CALLBACK find_best_window_cb(HWND hwnd, LPARAM lParam)
 {
-	auto *data = reinterpret_cast<enum_wnd_data *>(lParam);
+	auto *data = reinterpret_cast<enum_best_wnd_data *>(lParam);
 	DWORD pid = 0;
 	GetWindowThreadProcessId(hwnd, &pid);
 
-	if (pid == data->target_pid && IsWindowVisible(hwnd) && GetWindow(hwnd, GW_OWNER) == NULL) {
-		data->result = hwnd;
-		return FALSE;
+	bool pid_match = false;
+	for (DWORD p : data->pids) {
+		if (p == pid) {
+			pid_match = true;
+			break;
+		}
+	}
+
+	if (pid_match && IsWindowVisible(hwnd) && GetWindow(hwnd, GW_OWNER) == NULL) {
+		RECT rc;
+		if (GetWindowRect(hwnd, &rc)) {
+			int area = (rc.right - rc.left) * (rc.bottom - rc.top);
+			if (area > data->best_area) {
+				data->best_area = area;
+				data->result = hwnd;
+			}
+		}
 	}
 	return TRUE;
 }
 
-void blocker_panel::bring_to_front(DWORD pid)
+static std::vector<DWORD> find_pids_for_exe(const std::wstring &exe_path)
+{
+	std::vector<DWORD> pids;
+	if (exe_path.empty())
+		return pids;
+
+	HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+	if (snap == INVALID_HANDLE_VALUE)
+		return pids;
+
+	PROCESSENTRY32W pe = {sizeof(pe)};
+	if (Process32FirstW(snap, &pe)) {
+		do {
+			HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pe.th32ProcessID);
+			if (hProc) {
+				WCHAR sz[MAX_PATH];
+				DWORD cch = MAX_PATH;
+				if (QueryFullProcessImageNameW(hProc, 0, sz, &cch) && cch <= MAX_PATH) {
+					if (_wcsicmp(sz, exe_path.c_str()) == 0) {
+						pids.push_back(pe.th32ProcessID);
+					}
+				}
+				CloseHandle(hProc);
+			}
+		} while (Process32NextW(snap, &pe));
+	}
+	CloseHandle(snap);
+	return pids;
+}
+
+void blocker_panel::bring_to_front(DWORD pid, const std::wstring &exe_path)
 {
 	if (pid == 0)
 		return;
 
-	enum_wnd_data data = {pid, NULL};
-	EnumWindows(find_main_window_cb, (LPARAM)&data);
+	/* Collect all PIDs running the same executable so we can find the main
+	 * window even when the DLL-locking process is a worker/child. */
+	std::vector<DWORD> pids = find_pids_for_exe(exe_path);
+	if (pids.empty())
+		pids.push_back(pid);
+
+	/* Pick the largest visible top-level window — most likely the main
+	 * application window rather than a small overlay or notification. */
+	enum_best_wnd_data data = {std::move(pids), NULL, 0};
+	EnumWindows(find_best_window_cb, (LPARAM)&data);
 
 	if (data.result) {
 		if (IsIconic(data.result)) {
@@ -292,15 +346,10 @@ bool blocker_panel::handle_click(LPARAM lParam)
 	if (!pnm || pnm->hdr.hwndFrom != hwnd_)
 		return false;
 
-	if (pnm->iSubItem == COL_POPUP && pnm->iItem >= 0) {
-		LVITEM lvi = {0};
-		lvi.mask = LVIF_PARAM;
-		lvi.iItem = pnm->iItem;
-		if (ListView_GetItem(hwnd_, &lvi)) {
-			DWORD pid = (DWORD)lvi.lParam;
-			bring_to_front(pid);
-			return true;
-		}
+	if (pnm->iSubItem == COL_POPUP && pnm->iItem >= 0 && pnm->iItem < (int)blockers_.size()) {
+		const auto &info = blockers_[pnm->iItem];
+		bring_to_front(info.pid, info.exe_path);
+		return true;
 	}
 	return false;
 }

--- a/src/blocker-panel.hpp
+++ b/src/blocker-panel.hpp
@@ -30,7 +30,7 @@ struct blocker_panel : public content_panel {
 
 	void set_blockers(const std::vector<blocker_info> &blockers);
 
-	static void bring_to_front(DWORD pid);
+	static void bring_to_front(DWORD pid, const std::wstring &exe_path);
 
 	bool handle_click(LPARAM lParam);
 

--- a/src/update-blockers.cc
+++ b/src/update-blockers.cc
@@ -2,6 +2,7 @@
 #include "logger/log.h"
 
 #include <algorithm>
+#include <tlhelp32.h>
 #include <unordered_map>
 
 #pragma comment(lib, "Rstrtmgr.lib")
@@ -220,6 +221,42 @@ std::vector<blocker_info> get_blocker_details(blockers_map_t &blockers)
 			seen[key] = result.size();
 			result.push_back(std::move(info));
 		}
+	}
+
+	/* Check sibling processes for visible windows. The PIDs reported by
+	 * the Restart Manager are often worker/child processes (e.g. Chrome
+	 * GPU process) that don't own the main app window. */
+	for (auto &info : result) {
+		if (info.has_window || info.exe_path.empty())
+			continue;
+
+		HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+		if (snap == INVALID_HANDLE_VALUE)
+			continue;
+
+		PROCESSENTRY32W pe = {sizeof(pe)};
+		if (Process32FirstW(snap, &pe)) {
+			do {
+				HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pe.th32ProcessID);
+				if (hProc) {
+					WCHAR sz[MAX_PATH];
+					DWORD cch = MAX_PATH;
+					if (QueryFullProcessImageNameW(hProc, 0, sz, &cch) && cch <= MAX_PATH) {
+						if (_wcsicmp(sz, info.exe_path.c_str()) == 0) {
+							find_window_data fwd = {pe.th32ProcessID, false};
+							EnumWindows(find_visible_window_cb, (LPARAM)&fwd);
+							if (fwd.found) {
+								info.has_window = true;
+							}
+						}
+					}
+					CloseHandle(hProc);
+				}
+				if (info.has_window)
+					break;
+			} while (Process32NextW(snap, &pe));
+		}
+		CloseHandle(snap);
 	}
 
 	/* Disambiguate entries that share the same app_name but have different

--- a/src/update-blockers.cc
+++ b/src/update-blockers.cc
@@ -2,8 +2,10 @@
 #include "logger/log.h"
 
 #include <algorithm>
+#include <unordered_map>
 
 #pragma comment(lib, "Rstrtmgr.lib")
+#pragma comment(lib, "Version.lib")
 
 bool is_virtualcam_file(const fs::path &relative_path)
 {
@@ -130,9 +132,43 @@ static BOOL CALLBACK find_visible_window_cb(HWND hwnd, LPARAM lParam)
 	return TRUE;
 }
 
+static std::wstring get_file_description(const std::wstring &exe_path)
+{
+	if (exe_path.empty())
+		return {};
+
+	DWORD dummy = 0;
+	DWORD size = GetFileVersionInfoSizeW(exe_path.c_str(), &dummy);
+	if (size == 0)
+		return {};
+
+	std::vector<BYTE> buffer(size);
+	if (!GetFileVersionInfoW(exe_path.c_str(), 0, size, buffer.data()))
+		return {};
+
+	struct LANGANDCODEPAGE {
+		WORD wLanguage;
+		WORD wCodePage;
+	} *translations = nullptr;
+	UINT trans_size = 0;
+
+	if (!VerQueryValueW(buffer.data(), L"\\VarFileInfo\\Translation", (LPVOID *)&translations, &trans_size) || trans_size < sizeof(*translations))
+		return {};
+
+	wchar_t sub_block[64];
+	swprintf(sub_block, 64, L"\\StringFileInfo\\%04x%04x\\FileDescription", translations[0].wLanguage, translations[0].wCodePage);
+
+	LPWSTR description = nullptr;
+	UINT desc_len = 0;
+	if (VerQueryValueW(buffer.data(), sub_block, (LPVOID *)&description, &desc_len) && desc_len > 0)
+		return std::wstring(description);
+
+	return {};
+}
+
 std::vector<blocker_info> get_blocker_details(blockers_map_t &blockers)
 {
-	std::vector<blocker_info> result;
+	std::vector<blocker_info> all_entries;
 	std::unique_lock<std::mutex> ulock(blockers.mtx);
 
 	for (auto &entry : blockers.list) {
@@ -161,7 +197,57 @@ std::vector<blocker_info> get_blocker_details(blockers_map_t &blockers)
 			info.has_window = fwd.found;
 		}
 
-		result.push_back(std::move(info));
+		all_entries.push_back(std::move(info));
+	}
+	ulock.unlock();
+
+	/* Deduplicate: group by exe_path (or app_name if exe_path is empty).
+	 * Keep the entry with has_window=true when possible, so the "Bring up"
+	 * button targets the interactive process. */
+	std::unordered_map<std::wstring, size_t> seen;
+	std::vector<blocker_info> result;
+
+	for (auto &info : all_entries) {
+		const std::wstring &key = info.exe_path.empty() ? info.app_name : info.exe_path;
+
+		auto it = seen.find(key);
+		if (it != seen.end()) {
+			/* Prefer the entry with a visible window */
+			if (info.has_window && !result[it->second].has_window) {
+				result[it->second] = std::move(info);
+			}
+		} else {
+			seen[key] = result.size();
+			result.push_back(std::move(info));
+		}
+	}
+
+	/* Disambiguate entries that share the same app_name but have different
+	 * exe_path (e.g. Chrome vs Chrome Beta both report "Google Chrome").
+	 * Use FileDescription from version info for a better display name. */
+	std::unordered_map<std::wstring, int> name_counts;
+	for (auto &info : result)
+		name_counts[info.app_name]++;
+
+	for (auto &info : result) {
+		if (name_counts[info.app_name] <= 1)
+			continue;
+
+		std::wstring desc = get_file_description(info.exe_path);
+		if (!desc.empty() && desc != info.app_name) {
+			info.app_name = desc;
+		} else if (!info.exe_path.empty()) {
+			/* Fallback: use the product folder from the exe path
+			 * e.g. "C:\...\Chrome Beta\Application\chrome.exe" -> "Chrome Beta" */
+			fs::path exe(info.exe_path);
+			fs::path parent = exe.parent_path();
+			if (parent.has_parent_path()) {
+				std::wstring folder = parent.parent_path().filename().wstring();
+				if (!folder.empty()) {
+					info.app_name += L" (" + folder + L")";
+				}
+			}
+		}
 	}
 
 	return result;


### PR DESCRIPTION
Fixes for duplicate entities in list of apps blocking update: 
some apps can have same simple name , like chrome and chrome beta both have short name Chrome. 
some apps like nvidia broadcast can lock files from more than one process. 

Minor fix for Bring Front button. 