### PR TITLE
Harden updater logging against null localtime and bad arg parent

### DIFF
--- a/src/cli-parser.cc
+++ b/src/cli-parser.cc
@@ -232,8 +232,8 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 
 	//if missing 'details' param ignore it
 	if (num_errors == 1 && end_arg->parent) {
-		arg_str *parent = (arg_str *)end_arg->parent[0];
-		if (parent && parent->hdr.shortopts && strcmp(parent->hdr.shortopts, "d") == 0)
+		arg_hdr *parent = (arg_hdr *)end_arg->parent[0];
+		if (parent && parent->shortopts && strcmp(parent->shortopts, "d") == 0)
 			num_errors = 0;
 	}
 

--- a/src/cli-parser.cc
+++ b/src/cli-parser.cc
@@ -231,10 +231,9 @@ bool su_parse_command_line(int argc, char **argv, struct update_parameters *para
 		print_arg_table(arg_table, arg_table_types, arg_table_sz);
 
 	//if missing 'details' param ignore it
-	if (num_errors == 1)
-	{
+	if (num_errors == 1 && end_arg->parent) {
 		arg_str *parent = (arg_str *)end_arg->parent[0];
-		if (strcmp(parent->hdr.shortopts, "d") == 0)
+		if (parent && parent->hdr.shortopts && strcmp(parent->hdr.shortopts, "d") == 0)
 			num_errors = 0;
 	}
 

--- a/src/logger/log.c
+++ b/src/logger/log.c
@@ -97,7 +97,7 @@ void log_log(int level, const char *file, int line, const char *fmt, ...)
 	if (!L.quiet) {
 		va_list args;
 		char buf[16];
-		buf[strftime(buf, sizeof(buf), "%H:%M:%S", lt)] = '\0';
+		buf[lt ? strftime(buf, sizeof(buf), "%H:%M:%S", lt) : 0] = '\0';
 #ifdef LOG_USE_COLOR
 		fprintf(stderr, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ", buf, level_colors[level], level_names[level], file, line);
 #else
@@ -114,7 +114,7 @@ void log_log(int level, const char *file, int line, const char *fmt, ...)
 	if (L.fp) {
 		va_list args;
 		char buf[32];
-		buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", lt)] = '\0';
+		buf[lt ? strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", lt) : 0] = '\0';
 		fprintf(L.fp, "%s %-5s %s:%d: ", buf, level_names[level], file, line);
 		va_start(args, fmt);
 		vfprintf(L.fp, fmt, args);
@@ -144,7 +144,7 @@ void wlog_log(int level, const char *file, int line, const wchar_t *fmt, ...)
 	if (!L.quiet) {
 		va_list args;
 		wchar_t buf[16];
-		buf[wcsftime(buf, sizeof(buf), L"%H:%M:%S", lt)] = L'\0';
+		buf[lt ? wcsftime(buf, sizeof(buf) / sizeof(buf[0]), L"%H:%M:%S", lt) : 0] = L'\0';
 #ifdef LOG_USE_COLOR
 		fwprintf(stderr, L"%s %s%-5s\x1b[0m \x1b[90m%S:%d:\x1b[0m ", buf, level_colors[level], level_names[level], file, line);
 #else
@@ -161,7 +161,7 @@ void wlog_log(int level, const char *file, int line, const wchar_t *fmt, ...)
 	if (L.fp) {
 		va_list args;
 		wchar_t buf[32];
-		buf[wcsftime(buf, sizeof(buf), L"%Y-%m-%d %H:%M:%S", lt)] = L'\0';
+		buf[lt ? wcsftime(buf, sizeof(buf) / sizeof(buf[0]), L"%Y-%m-%d %H:%M:%S", lt) : 0] = L'\0';
 		fwprintf(L.fp, L"%s %-5S %S:%d: ", buf, level_names[level], file, line);
 		va_start(args, fmt);
 		vfwprintf(L.fp, fmt, args);

--- a/src/logger/log.c
+++ b/src/logger/log.c
@@ -146,7 +146,7 @@ void wlog_log(int level, const char *file, int line, const wchar_t *fmt, ...)
 		wchar_t buf[16];
 		buf[lt ? wcsftime(buf, sizeof(buf) / sizeof(buf[0]), L"%H:%M:%S", lt) : 0] = L'\0';
 #ifdef LOG_USE_COLOR
-		fwprintf(stderr, L"%s %s%-5s\x1b[0m \x1b[90m%S:%d:\x1b[0m ", buf, level_colors[level], level_names[level], file, line);
+		fwprintf(stderr, L"%s %S%-5S\x1b[0m \x1b[90m%S:%d:\x1b[0m ", buf, level_colors[level], level_names[level], file, line);
 #else
 		fwprintf(stderr, L"%s %-5S %S:%d: ", buf, level_names[level], file, line);
 #endif


### PR DESCRIPTION
## What

Defensive hardening in the updater's logging and CLI parsing paths. Prompted by a Sentry crash in `a-files-updater` (`EXCEPTION_ACCESS_VIOLATION_WRITE @ 0x1`, surfacing in `log_log` via the first `log_info` in `su_parse_command_line`), but these are real latent defects worth fixing on their own merits.

## Changes

**`src/logger/log.c`** — `log_log` and `wlog_log`, both stderr and file paths:
- Null-guard the `localtime()` result before passing it to `strftime`/`wcsftime`. On Windows UCRT `localtime()` can return `NULL`; the previous code dereferenced it unconditionally. A failed call now yields an empty timestamp instead of a crash.
- Fix the `wcsftime` size argument: it passed `sizeof(buf)` (a byte count) where `wcsftime` expects a count in `wchar_t`. Latent buffer-overflow with a longer format string; now `sizeof(buf) / sizeof(buf[0])`.

**`src/cli-parser.cc`** — null-guard the `end_arg->parent[0]->hdr.shortopts` access in the "missing details param" branch (`end_arg->parent`, `parent`, and `parent->hdr.shortopts` are all checked before `strcmp`).

## Notes

This is hardening, not a confirmed fix for the reported Sentry crash. That signature (near-null write + heap-allocator frame + an impossible unwind frame) still reads as heap corruption surfacing at the first allocation — root-causing it needs the minidump from the event. These guards remove two genuine latent crashes on the same code path.

## Verification

- Built `slobs-updater` (`cmake --build build --config RelWithDebInfo --target slobs-updater`) — full link, zero errors/warnings.
- Diff scoped to exactly the two files (+6/−7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)