### PR TITLE
Fix hang during required component download and improve package phase UX

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -744,8 +744,9 @@ void callbacks_impl::installer_download_start(const std::string &packageName)
 	std::wstring skip_label = ConvertToUtf16WS(boost::locale::translate("Skip"));
 	{
 		std::lock_guard<std::mutex> lock(cancel_label_mutex);
+		if (!package_phase_active)
+			saved_cancel_label = cancel_label;
 		package_phase_active = true;
-		saved_cancel_label = cancel_label;
 		cancel_label = skip_label;
 	}
 	SetWindowTextW(cancel_button, skip_label.c_str());

--- a/src/main.cc
+++ b/src/main.cc
@@ -16,6 +16,7 @@
 #include "blocker-panel.hpp"
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <thread>
 #include <fstream>
@@ -152,6 +153,9 @@ struct callbacks_impl : public install_callbacks,
 	bool cancel_silent{false};
 	bool package_phase_active{false};
 	std::wstring saved_cancel_label;
+	// Guards cancel_label/saved_cancel_label/package_phase_active (worker vs UI thread).
+	// Never hold across SetWindowTextW - it SendMessages the UI thread and would deadlock.
+	std::mutex cancel_label_mutex;
 	LPCWSTR label_format{L"Downloading {} of {} - {:.2f} MB/s"};
 
 	callbacks_impl(const callbacks_impl &) = delete;
@@ -737,10 +741,14 @@ void callbacks_impl::installer_download_start(const std::string &packageName)
 	SelectObject(hdc, hfontOld);
 	ReleaseDC(frame, hdc);
 
-	package_phase_active = true;
-	saved_cancel_label = cancel_label;
-	cancel_label = ConvertToUtf16WS(boost::locale::translate("Skip"));
-	SetWindowTextW(cancel_button, cancel_label.c_str());
+	std::wstring skip_label = ConvertToUtf16WS(boost::locale::translate("Skip"));
+	{
+		std::lock_guard<std::mutex> lock(cancel_label_mutex);
+		package_phase_active = true;
+		saved_cancel_label = cancel_label;
+		cancel_label = skip_label;
+	}
+	SetWindowTextW(cancel_button, skip_label.c_str());
 
 	ShowWindow(cancel_button, SW_SHOW);
 	ShowWindow(continue_button, SW_HIDE);
@@ -1086,8 +1094,13 @@ void callbacks_impl::hide_ui_elements()
 
 void callbacks_impl::reset_ui_labels()
 {
+	std::wstring cancel_copy;
+	{
+		std::lock_guard<std::mutex> lock(cancel_label_mutex);
+		cancel_copy = cancel_label;
+	}
 	SetWindowTextW(continue_button, continue_label.c_str());
-	SetWindowTextW(cancel_button, cancel_label.c_str());
+	SetWindowTextW(cancel_button, cancel_copy.c_str());
 
 	update_btn_label = ConvertToUtf16WS(boost::locale::translate("Upgrade"));
 	remind_btn_label = ConvertToUtf16WS(boost::locale::translate("Later"));
@@ -1097,13 +1110,18 @@ void callbacks_impl::reset_ui_labels()
 
 void callbacks_impl::restore_cancel_button_text()
 {
-	if (!saved_cancel_label.empty()) {
-		cancel_label = saved_cancel_label;
-		saved_cancel_label.clear();
+	std::wstring to_set;
+	{
+		std::lock_guard<std::mutex> lock(cancel_label_mutex);
+		if (!saved_cancel_label.empty()) {
+			cancel_label = saved_cancel_label;
+			saved_cancel_label.clear();
+		}
+		package_phase_active = false;
+		to_set = cancel_label;
 	}
-	package_phase_active = false;
 	if (cancel_button != NULL) {
-		SetWindowTextW(cancel_button, cancel_label.c_str());
+		SetWindowTextW(cancel_button, to_set.c_str());
 	}
 }
 
@@ -1466,7 +1484,12 @@ LRESULT CALLBACK FrameWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			EnableWindow(ctx->kill_button, false);
 			EnableWindow(ctx->continue_button, false);
 			EnableWindow(ctx->cancel_button, false);
-			if (ctx->package_phase_active) {
+			bool in_package_phase;
+			{
+				std::lock_guard<std::mutex> lock(ctx->cancel_label_mutex);
+				in_package_phase = ctx->package_phase_active;
+			}
+			if (in_package_phase) {
 				ctx->restore_cancel_button_text();
 			} else {
 				ctx->cancel_silent = true;
@@ -1539,7 +1562,12 @@ LRESULT CALLBACK FrameWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			if (ctx->prompting) {
 				DrawText(dis->hDC, ctx->remind_btn_label.c_str(), -1, &dis->rcItem, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
 			} else {
-				DrawText(dis->hDC, ctx->cancel_label.c_str(), -1, &dis->rcItem, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+				std::wstring cancel_copy;
+				{
+					std::lock_guard<std::mutex> lock(ctx->cancel_label_mutex);
+					cancel_copy = ctx->cancel_label;
+				}
+				DrawText(dis->hDC, cancel_copy.c_str(), -1, &dis->rcItem, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
 			}
 		}
 		if (dis->hwndItem == ctx->kill_button) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -1466,10 +1466,10 @@ LRESULT CALLBACK FrameWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			EnableWindow(ctx->kill_button, false);
 			EnableWindow(ctx->continue_button, false);
 			EnableWindow(ctx->cancel_button, false);
-			ctx->cancel_silent = true;
 			if (ctx->package_phase_active) {
 				ctx->restore_cancel_button_text();
 			} else {
+				ctx->cancel_silent = true;
 				ctx->should_cancel = true;
 			}
 			if (ctx->client_ptr) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -116,6 +116,7 @@ struct callbacks_impl : public install_callbacks,
 	HWND kill_button{NULL};
 	HWND continue_button{NULL};
 	HWND cancel_button{NULL};
+	struct update_client *client_ptr{NULL};
 	std::wstring update_btn_label;
 	std::wstring remind_btn_label;
 	std::wstring continue_label;
@@ -149,6 +150,8 @@ struct callbacks_impl : public install_callbacks,
 	bool finished_downloading{false};
 	bool prompting{false};
 	bool cancel_silent{false};
+	bool package_phase_active{false};
+	std::wstring saved_cancel_label;
 	LPCWSTR label_format{L"Downloading {} of {} - {:.2f} MB/s"};
 
 	callbacks_impl(const callbacks_impl &) = delete;
@@ -161,6 +164,7 @@ struct callbacks_impl : public install_callbacks,
 
 	void setupFont();
 	void repostionUI();
+	void restore_cancel_button_text();
 
 	void initialize(struct update_client *client) final;
 	void success() final;
@@ -563,12 +567,14 @@ void callbacks_impl::initialize(struct update_client *client)
 
 void callbacks_impl::success()
 {
+	restore_cancel_button_text();
 	should_start = true;
 	PostMessage(frame, CUSTOM_CLOSE_MSG, NULL, NULL);
 }
 
 void callbacks_impl::error(const std::string &error, const std::string &category, const std::string &reason)
 {
+	restore_cancel_button_text();
 	this->error_buf = error;
 	save_exit_error(category, reason);
 
@@ -583,6 +589,8 @@ void callbacks_impl::downloader_preparing(bool connected)
 	if (ctx->prompting) {
 		return;
 	}
+
+	ctx->restore_cancel_button_text();
 
 	std::wstring checking_label;
 	if (connected) {
@@ -714,7 +722,8 @@ void callbacks_impl::installer_download_start(const std::string &packageName)
 {
 	package_dl_pct100 = 0;
 	installer_download_progress(0);
-	std::wstring downloading_label = ConvertToUtf16WS(boost::locale::translate("Downloading"));
+
+	std::wstring downloading_label = ConvertToUtf16WS(boost::locale::translate("Downloading required component: "));
 	downloading_label += fmt::to_wstring(packageName) + L"...";
 
 	HDC hdc = GetDC(frame);
@@ -728,14 +737,25 @@ void callbacks_impl::installer_download_start(const std::string &packageName)
 	SelectObject(hdc, hfontOld);
 	ReleaseDC(frame, hdc);
 
+	package_phase_active = true;
+	saved_cancel_label = cancel_label;
+	cancel_label = ConvertToUtf16WS(boost::locale::translate("Skip"));
+	SetWindowTextW(cancel_button, cancel_label.c_str());
+
+	ShowWindow(cancel_button, SW_SHOW);
+	ShowWindow(continue_button, SW_HIDE);
+	ShowWindow(kill_button, SW_HIDE);
+	ShowWindow(progress_worker, SW_SHOW);
+
 	repostionUI();
 
 	SetWindowTextW(progress_label, downloading_label.c_str());
+
+	log_info("Package download/install UI shown for: %s", packageName.c_str());
 }
 
 void callbacks_impl::installer_download_progress(const double percent)
 {
-	// Too many PostMessage per/sec overwhelm gui refresh rate
 	int pct100 = int(percent * 100.0);
 
 	if (pct100 > package_dl_pct100) {
@@ -746,6 +766,8 @@ void callbacks_impl::installer_download_progress(const double percent)
 
 void callbacks_impl::installer_package_failed(const std::string &packageName, const std::string &message)
 {
+	restore_cancel_button_text();
+
 	if (message.empty())
 		MessageBoxA(frame, ("WARNING: Streamlabs Desktop was unable to download/install the required '" + packageName + "' package.").c_str(),
 			    "Package Installation", MB_OK | MB_ICONWARNING);
@@ -773,6 +795,8 @@ void callbacks_impl::installer_run_file(const std::string &packageName, const st
 	}
 
 	if (dwExitCode == ERROR_SUCCESS) {
+		log_info("Launching package installer for \"%s\" with params: %s", packageName.c_str(), startParams.c_str());
+
 		STARTUPINFOA si;
 		ZeroMemory(&si, sizeof(si));
 		si.cb = sizeof(si);
@@ -784,6 +808,8 @@ void callbacks_impl::installer_run_file(const std::string &packageName, const st
 				   &pi)) {
 			WaitForSingleObject(pi.hProcess, INFINITE);
 			GetExitCodeProcess(pi.hProcess, &dwExitCode);
+
+			log_info("Package installer for \"%s\" exited with code %lu", packageName.c_str(), dwExitCode);
 
 			CloseHandle(pi.hProcess);
 			CloseHandle(pi.hThread);
@@ -1067,6 +1093,18 @@ void callbacks_impl::reset_ui_labels()
 	remind_btn_label = ConvertToUtf16WS(boost::locale::translate("Later"));
 	trim_trailing_nuls(update_btn_label);
 	trim_trailing_nuls(remind_btn_label);
+}
+
+void callbacks_impl::restore_cancel_button_text()
+{
+	if (!saved_cancel_label.empty()) {
+		cancel_label = saved_cancel_label;
+		saved_cancel_label.clear();
+	}
+	package_phase_active = false;
+	if (cancel_button != NULL) {
+		SetWindowTextW(cancel_button, cancel_label.c_str());
+	}
 }
 
 bool callbacks_impl::run_message_loop(bool default_accept)
@@ -1429,7 +1467,14 @@ LRESULT CALLBACK FrameWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			EnableWindow(ctx->continue_button, false);
 			EnableWindow(ctx->cancel_button, false);
 			ctx->cancel_silent = true;
-			ctx->should_cancel = true;
+			if (ctx->package_phase_active) {
+				ctx->restore_cancel_button_text();
+			} else {
+				ctx->should_cancel = true;
+			}
+			if (ctx->client_ptr) {
+				update_client_cancel_install_packages(ctx->client_ptr);
+			}
 			break;
 		}
 	} break;
@@ -1647,10 +1692,10 @@ extern "C" int wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpC
 		update_client_set_disk_space_events(client.get(), &cb_impl);
 		update_client_set_installer_events(client.get(), &cb_impl);
 
+		cb_impl.client_ptr = client.get();
 		cb_impl.initialize(client.get());
 
 		std::thread workerThread([&]() {
-			// Threaded because package installations come first which is blocking from the perspective of the file updater
 			update_client_start(client.get());
 		});
 

--- a/src/update-client-internal.hpp
+++ b/src/update-client-internal.hpp
@@ -105,7 +105,7 @@ struct update_client {
 	bool show_user_blockers_list;
 	std::wstring process_list_text;
 
-	bool install_packages_cancelled = false;
+	std::atomic<bool> install_packages_cancelled{false};
 	boost::asio::deadline_timer package_download_timer;
 	std::atomic<uintptr_t> active_package_native_socket{~uintptr_t(0)};
 

--- a/src/update-client-internal.hpp
+++ b/src/update-client-internal.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "update-http-request.hpp"
 
+#include <atomic>
+#include <cstdint>
 #include <fstream>
 #include "utils.hpp"
 #include "checksum-filters.hpp"

--- a/src/update-client-internal.hpp
+++ b/src/update-client-internal.hpp
@@ -107,7 +107,7 @@ struct update_client {
 
 	bool install_packages_cancelled = false;
 	boost::asio::deadline_timer package_download_timer;
-	std::atomic<uintptr_t> active_package_native_socket{ ~uintptr_t(0) };
+	std::atomic<uintptr_t> active_package_native_socket{~uintptr_t(0)};
 
 	enum class blocker_phase { virtualcam, generic };
 	blocker_phase current_blocker_phase{blocker_phase::virtualcam};

--- a/src/update-client-internal.hpp
+++ b/src/update-client-internal.hpp
@@ -105,6 +105,10 @@ struct update_client {
 	bool show_user_blockers_list;
 	std::wstring process_list_text;
 
+	bool install_packages_cancelled = false;
+	boost::asio::deadline_timer package_download_timer;
+	std::atomic<uintptr_t> active_package_native_socket{ ~uintptr_t(0) };
+
 	enum class blocker_phase { virtualcam, generic };
 	blocker_phase current_blocker_phase{blocker_phase::virtualcam};
 
@@ -115,6 +119,8 @@ struct update_client {
 	boost::asio::deadline_timer domain_resolve_timeout;
 	void check_resolve_timeout_callback_err(const boost::system::error_code &error);
 	std::mutex handle_error_mutex;
+
+	void cancel_install_packages();
 
 private:
 	// [packageName] = { url, params }

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -389,6 +389,8 @@ void update_client::do_stuff()
 	for (auto &itr : install_packages) {
 		install_package(itr.first, itr.second.first, itr.second.second);
 		log_info("Finished processing package \"%s\".", itr.first.c_str());
+		if (install_packages_cancelled)
+			break;
 	}
 
 	if (install_packages_cancelled) {
@@ -441,18 +443,14 @@ void update_client::install_package(const std::string &packageName, std::string 
 
 	ssl::stream<tcp::socket> local_ssl_socket(io_ctx, ssl_context);
 
-	active_package_native_socket.store((uintptr_t)local_ssl_socket.lowest_layer().native_handle());
-
 	package_download_timer.expires_from_now(boost::posix_time::seconds(180));
-	package_download_timer.async_wait([this, packageName, h = (uintptr_t)local_ssl_socket.lowest_layer().native_handle()](const boost::system::error_code &ec) {
+	package_download_timer.async_wait([this, packageName](const boost::system::error_code &ec) {
 		if (ec)
 			return;
 		log_warn("Timeout for package %s download/install", packageName.c_str());
-		uintptr_t cur = active_package_native_socket.load();
-		if (cur == h) {
-			::closesocket((SOCKET)h);
-			active_package_native_socket.store(~uintptr_t(0));
-		}
+		uintptr_t s = active_package_native_socket.exchange(~uintptr_t(0));
+		if (s != ~uintptr_t(0))
+			::closesocket((SOCKET)s);
 	});
 
 	auto finish_package = [&]() {
@@ -460,10 +458,20 @@ void update_client::install_package(const std::string &packageName, std::string 
 		active_package_native_socket.store(~uintptr_t(0));
 	};
 
-	do {
-		local_ssl_socket.lowest_layer().close();
-		local_ssl_socket.lowest_layer().connect(*endpoint_iterator++, error);
-	} while (error && endpoint_iterator != tcp::resolver::iterator{});
+	// Open before each connect so the live handle is published (for the timeout/Skip
+	// path to close) before the blocking connect - native_handle() is invalid until open.
+	for (; endpoint_iterator != tcp::resolver::iterator{}; ++endpoint_iterator) {
+		local_ssl_socket.lowest_layer().close(error);
+		local_ssl_socket.lowest_layer().open(endpoint_iterator->endpoint().protocol(), error);
+		if (error.failed())
+			continue;
+
+		active_package_native_socket.store((uintptr_t)local_ssl_socket.lowest_layer().native_handle());
+
+		local_ssl_socket.lowest_layer().connect(*endpoint_iterator, error);
+		if (!error.failed())
+			break;
+	}
 
 	if (error.failed()) {
 		finish_package();

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -582,6 +582,11 @@ void update_client::install_package(const std::string &packageName, std::string 
 		return;
 	}
 
+	if (install_packages_cancelled) {
+		finish_package();
+		return;
+	}
+
 	try {
 		installer_events->installer_run_file(packageName, startParams, beast::buffers_to_string(local_response_parser.get().body().data()));
 	} catch (...) {

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -4,6 +4,8 @@
 #include <thread>
 #include <regex>
 
+#include <winsock2.h>
+
 
 
 #include <fmt/format.h>
@@ -263,7 +265,7 @@ void update_client::handle_resolve(const boost::system::error_code &error, resol
 }
 
 update_client::update_client(struct update_parameters *params)
-	: params(params), wait_for_blockers(io_ctx), show_user_blockers_list(true), active_workers(0), resolver(io_ctx), domain_resolve_timeout(io_ctx)
+	: params(params), wait_for_blockers(io_ctx), show_user_blockers_list(true), active_workers(0), resolver(io_ctx), domain_resolve_timeout(io_ctx), package_download_timer(io_ctx)
 {
 	new_files_dir = params->temp_dir;
 	new_files_dir /= "new-files";
@@ -307,6 +309,16 @@ void update_client::flush()
 	for (std::thread &thrd : thread_pool) {
 		thrd.join();
 	}
+}
+
+void update_client::cancel_install_packages()
+{
+	install_packages_cancelled = true;
+	uintptr_t s = active_package_native_socket.exchange(~uintptr_t(0));
+	if (s != ~uintptr_t(0)) {
+		::closesocket((SOCKET)s);
+	}
+	package_download_timer.cancel();
 }
 
 bool update_client::check_disk_space()
@@ -374,9 +386,15 @@ void update_client::do_stuff()
 		return;
 	}
 
-	// [packageName] = { url, params }
-	for (auto &itr : install_packages)
+	for (auto &itr : install_packages) {
 		install_package(itr.first, itr.second.first, itr.second.second);
+		log_info("Finished processing package \"%s\".", itr.first.c_str());
+	}
+
+	if (install_packages_cancelled) {
+		log_info("Package installation was skipped (user chose Skip or was cancelled). Continuing with main update.");
+		install_packages_cancelled = false;
+	}
 
 	domain_resolve_timeout.expires_from_now(boost::posix_time::seconds(10));
 	check_resolve_timeout_callback_err({});
@@ -392,10 +410,11 @@ void update_client::install_package(const std::string &packageName, std::string 
 {
 	installer_events->installer_download_start(packageName);
 
+	log_info("Starting package download/install for \"%s\" (from %s)", packageName.c_str(), url.c_str());
+
 	boost::system::error_code error;
 	boost::asio::io_service io_service;
 
-	// Deduce domain from url
 	std::string domainName;
 	boost::replace_all(url, "https://", "");
 	boost::replace_all(url, "http://", "");
@@ -407,7 +426,6 @@ void update_client::install_package(const std::string &packageName, std::string 
 		domainName.push_back(url[itr]);
 	}
 
-	// Resolve domain to IP
 	tcp::resolver local_resolver(io_service);
 	tcp::resolver::iterator endpoint_iterator = local_resolver.resolve(
 		tcp::resolver::query{
@@ -421,8 +439,26 @@ void update_client::install_package(const std::string &packageName, std::string 
 		return;
 	}
 
-	// Try connect each endpoint until success
 	ssl::stream<tcp::socket> local_ssl_socket(io_ctx, ssl_context);
+
+	active_package_native_socket.store((uintptr_t)local_ssl_socket.lowest_layer().native_handle());
+
+	package_download_timer.expires_from_now(boost::posix_time::seconds(180));
+	package_download_timer.async_wait([this, packageName, h = (uintptr_t)local_ssl_socket.lowest_layer().native_handle()](const boost::system::error_code &ec) {
+		if (ec)
+			return;
+		log_warn("Timeout for package %s download/install", packageName.c_str());
+		uintptr_t cur = active_package_native_socket.load();
+		if (cur == h) {
+			::closesocket((SOCKET)h);
+			active_package_native_socket.store(~uintptr_t(0));
+		}
+	});
+
+	auto finish_package = [&]() {
+		package_download_timer.cancel();
+		active_package_native_socket.store(~uintptr_t(0));
+	};
 
 	do {
 		local_ssl_socket.lowest_layer().close();
@@ -430,30 +466,35 @@ void update_client::install_package(const std::string &packageName, std::string 
 	} while (error && endpoint_iterator != tcp::resolver::iterator{});
 
 	if (error.failed()) {
+		finish_package();
+		if (install_packages_cancelled)
+			return;
 		installer_events->installer_package_failed(packageName, "HTTP(2) " + error.message());
 		return;
 	}
 
-	// Timeout - Not 3 seconds to get everything, the max duration to go without back/forth activity
 	int32_t timeout = 3000;
 	::setsockopt(local_ssl_socket.lowest_layer().native_handle(), SOL_SOCKET, SO_SNDTIMEO, (const char *)&timeout, sizeof(timeout));
 	::setsockopt(local_ssl_socket.lowest_layer().native_handle(), SOL_SOCKET, SO_RCVTIMEO, (const char *)&timeout, sizeof(timeout));
 
-	// Set SNI hostname for TLS - required for CloudFlare and other CDNs
 	if (!SSL_set_tlsext_host_name(local_ssl_socket.native_handle(), domainName.c_str())) {
+		finish_package();
+		if (install_packages_cancelled)
+			return;
 		installer_events->installer_package_failed(packageName, "HTTP(2.5) Failed to set SNI hostname");
 		return;
 	}
 
-	// Handshake
 	local_ssl_socket.handshake(ssl::stream_base::handshake_type::client, error);
 
 	if (error.failed()) {
+		finish_package();
+		if (install_packages_cancelled)
+			return;
 		installer_events->installer_package_failed(packageName, "HTTP(3) " + error.message());
 		return;
 	}
 
-	// Send the first request
 	http::request<http::empty_body> local_request;
 	std::string target = url.substr(domainName.length());
 	if (target.empty())
@@ -467,22 +508,30 @@ void update_client::install_package(const std::string &packageName, std::string 
 	http::write(local_ssl_socket, local_request, error);
 
 	if (error.failed()) {
+		finish_package();
+		if (install_packages_cancelled)
+			return;
 		installer_events->installer_package_failed(packageName, "HTTP(4) " + error.message());
 		return;
 	}
 
-	// Check that response is OK
 	beast::multi_buffer local_response_buf;
 	http::response_parser<http::dynamic_body> local_response_parser;
 	local_response_parser.body_limit(std::numeric_limits<unsigned long long>::max());
 	http::read_header(local_ssl_socket, local_response_buf, local_response_parser, error);
 
 	if (error.failed()) {
+		finish_package();
+		if (install_packages_cancelled)
+			return;
 		installer_events->installer_package_failed(packageName, "HTTP(5) " + error.message());
 		return;
 	}
 
 	if (local_response_parser.get().result_int() != 200) {
+		finish_package();
+		if (install_packages_cancelled)
+			return;
 		installer_events->installer_package_failed(packageName, "HTTP Status Code " + std::to_string(local_response_parser.get().result_int()));
 		return;
 	}
@@ -493,13 +542,18 @@ void update_client::install_package(const std::string &packageName, std::string 
 	} catch (...) {
 	}
 
-	if (content_length == 0)
+	if (content_length == 0) {
+		finish_package();
 		return;
+	}
 
 	do {
 		try {
 			http::read_some(local_ssl_socket, local_response_buf, local_response_parser, error);
 		} catch (const boost::system::system_error &ex) {
+			finish_package();
+			if (install_packages_cancelled)
+				return;
 			installer_events->installer_package_failed(packageName, "HTTP(6) " + ex.code().message());
 			return;
 		}
@@ -508,6 +562,9 @@ void update_client::install_package(const std::string &packageName, std::string 
 	} while (!error.failed() && !local_response_parser.is_done());
 
 	if (error.failed()) {
+		finish_package();
+		if (install_packages_cancelled)
+			return;
 		installer_events->installer_package_failed(packageName, "HTTP(7) " + error.message());
 		return;
 	}
@@ -515,9 +572,15 @@ void update_client::install_package(const std::string &packageName, std::string 
 	try {
 		installer_events->installer_run_file(packageName, startParams, beast::buffers_to_string(local_response_parser.get().body().data()));
 	} catch (...) {
-		// local_response_parser throws
+		finish_package();
+		if (install_packages_cancelled)
+			return;
 		installer_events->installer_package_failed(packageName, "Unknown Error");
+		return;
 	}
+
+	log_info("Package \"%s\" download and execution completed.", packageName.c_str());
+	finish_package();
 }
 
 void update_client::set_endpoint_fail(const std::string &used_cdn_node_address)
@@ -1298,5 +1361,10 @@ void update_client_start(struct update_client *client)
 void update_client_flush(struct update_client *client)
 {
 	client->flush();
+}
+
+void update_client_cancel_install_packages(struct update_client *client)
+{
+	client->cancel_install_packages();
 }
 }

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -314,11 +314,12 @@ void update_client::flush()
 void update_client::cancel_install_packages()
 {
 	install_packages_cancelled = true;
+	// UI thread must not touch the asio timer; finish_package cancels it on the worker
+	// thread once the closed socket unblocks the synchronous op.
 	uintptr_t s = active_package_native_socket.exchange(~uintptr_t(0));
 	if (s != ~uintptr_t(0)) {
 		::closesocket((SOCKET)s);
 	}
-	package_download_timer.cancel();
 }
 
 bool update_client::check_disk_space()
@@ -447,10 +448,12 @@ void update_client::install_package(const std::string &packageName, std::string 
 	package_download_timer.async_wait([this, packageName](const boost::system::error_code &ec) {
 		if (ec)
 			return;
-		log_warn("Timeout for package %s download/install", packageName.c_str());
+		// Act only if the handle is still live - Skip/normal completion may have swapped it out.
 		uintptr_t s = active_package_native_socket.exchange(~uintptr_t(0));
-		if (s != ~uintptr_t(0))
+		if (s != ~uintptr_t(0)) {
+			log_warn("Timeout for package %s download/install", packageName.c_str());
 			::closesocket((SOCKET)s);
+		}
 	});
 
 	auto finish_package = [&]() {
@@ -466,6 +469,8 @@ void update_client::install_package(const std::string &packageName, std::string 
 		if (error.failed())
 			continue;
 
+		// Force-closed out-of-band by Skip/timeout to interrupt the blocking ops below;
+		// safe here because no other socket is opened on io_ctx during the package phase.
 		active_package_native_socket.store((uintptr_t)local_ssl_socket.lowest_layer().native_handle());
 
 		local_ssl_socket.lowest_layer().connect(*endpoint_iterator, error);

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -473,6 +473,13 @@ void update_client::install_package(const std::string &packageName, std::string 
 		// safe here because no other socket is opened on io_ctx during the package phase.
 		active_package_native_socket.store((uintptr_t)local_ssl_socket.lowest_layer().native_handle());
 
+		// A Skip that arrived before the handle was published could not close the
+		// socket; bail before the blocking connect so Skip does not appear to hang.
+		if (install_packages_cancelled) {
+			finish_package();
+			return;
+		}
+
 		local_ssl_socket.lowest_layer().connect(*endpoint_iterator, error);
 		if (!error)
 			break;

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -265,7 +265,7 @@ void update_client::handle_resolve(const boost::system::error_code &error, resol
 }
 
 update_client::update_client(struct update_parameters *params)
-	: params(params), wait_for_blockers(io_ctx), show_user_blockers_list(true), active_workers(0), resolver(io_ctx), domain_resolve_timeout(io_ctx), package_download_timer(io_ctx)
+	: params(params), wait_for_blockers(io_ctx), show_user_blockers_list(true), active_workers(0), resolver(io_ctx), package_download_timer(io_ctx), domain_resolve_timeout(io_ctx)
 {
 	new_files_dir = params->temp_dir;
 	new_files_dir /= "new-files";
@@ -437,7 +437,7 @@ void update_client::install_package(const std::string &packageName, std::string 
 		},
 		error);
 
-	if (error.failed()) {
+	if (error) {
 		installer_events->installer_package_failed(packageName, "HTTP(1) " + error.message());
 		return;
 	}
@@ -466,7 +466,7 @@ void update_client::install_package(const std::string &packageName, std::string 
 	for (; endpoint_iterator != tcp::resolver::iterator{}; ++endpoint_iterator) {
 		local_ssl_socket.lowest_layer().close(error);
 		local_ssl_socket.lowest_layer().open(endpoint_iterator->endpoint().protocol(), error);
-		if (error.failed())
+		if (error)
 			continue;
 
 		// Force-closed out-of-band by Skip/timeout to interrupt the blocking ops below;
@@ -474,11 +474,11 @@ void update_client::install_package(const std::string &packageName, std::string 
 		active_package_native_socket.store((uintptr_t)local_ssl_socket.lowest_layer().native_handle());
 
 		local_ssl_socket.lowest_layer().connect(*endpoint_iterator, error);
-		if (!error.failed())
+		if (!error)
 			break;
 	}
 
-	if (error.failed()) {
+	if (error) {
 		finish_package();
 		if (install_packages_cancelled)
 			return;
@@ -500,7 +500,7 @@ void update_client::install_package(const std::string &packageName, std::string 
 
 	local_ssl_socket.handshake(ssl::stream_base::handshake_type::client, error);
 
-	if (error.failed()) {
+	if (error) {
 		finish_package();
 		if (install_packages_cancelled)
 			return;
@@ -520,7 +520,7 @@ void update_client::install_package(const std::string &packageName, std::string 
 
 	http::write(local_ssl_socket, local_request, error);
 
-	if (error.failed()) {
+	if (error) {
 		finish_package();
 		if (install_packages_cancelled)
 			return;
@@ -533,7 +533,7 @@ void update_client::install_package(const std::string &packageName, std::string 
 	local_response_parser.body_limit(std::numeric_limits<unsigned long long>::max());
 	http::read_header(local_ssl_socket, local_response_buf, local_response_parser, error);
 
-	if (error.failed()) {
+	if (error) {
 		finish_package();
 		if (install_packages_cancelled)
 			return;
@@ -572,9 +572,9 @@ void update_client::install_package(const std::string &packageName, std::string 
 		}
 
 		installer_events->installer_download_progress(double(local_response_parser.get().body().size()) / double(content_length));
-	} while (!error.failed() && !local_response_parser.is_done());
+	} while (!error && !local_response_parser.is_done());
 
-	if (error.failed()) {
+	if (error) {
 		finish_package();
 		if (install_packages_cancelled)
 			return;

--- a/src/update-client.hpp
+++ b/src/update-client.hpp
@@ -115,4 +115,6 @@ void update_client_start(struct update_client *);
 void update_client_flush(struct update_client *);
 
 void register_install_package(struct update_client *client, const std::string &packageName, const std::string &url, const std::string &startParams);
+
+void update_client_cancel_install_packages(struct update_client *client);
 }

--- a/src/update-http-request.hpp
+++ b/src/update-http-request.hpp
@@ -145,8 +145,10 @@ template<class Body, bool IncludeVersion> void update_http_request<Body, Include
 			log_error("Got error canceling timer");
 		}
 
+		// close() (not shutdown()) - only close cancels a pending overlapped read/connect
+		// on Windows, so the stalled handler actually fires and the worker is not lost.
 		boost::system::error_code ignored_ec;
-		ssl_socket.lowest_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);
+		ssl_socket.lowest_layer().close(ignored_ec);
 	} else {
 		// Put the actor back to sleep.
 		deadline.async_wait(bind(&update_http_request<Body, IncludeVersion>::check_deadline_callback_err, this, std::placeholders::_1));


### PR DESCRIPTION
### Problem
After accepting the release notes dialog, users could see a dialog containing only the label "Downloading" (no buttons, no progress bar) that would never advance or offer any way out. A memory dump showed the worker thread stuck in a synchronous `boost::asio` `connect` inside `install_package` (the path used for the Visual C++ Redistributable when the registry check says it is not present). The operation had no timeout, the UI thread had no way to abort it, and the package phase did not restore button/label state for subsequent steps.

Logs and the call stack pointed at the hardcoded VC redist download from `slobs-cdn.streamlabs.com` performed synchronously before the main manifest/CDN work.

### Solution
- Made the package install phase robust: a deadline timer now closes the native socket after 180 s, unblocking the synchronous operations running on the worker thread.
- Added an explicit abort path (`update_client_cancel_install_packages` + internal flag + socket close) that the UI can trigger.
- Improved UX for this step:
  - Label is now "Downloading required component: Visual C++ Redistributable..." so it is obvious this is a prerequisite runtime, not the main application update.
  - The button shown is "Skip" instead of "Cancel".
  - Clicking Skip aborts only the package download/install and lets the normal file update continue (no spurious warning box). Full update cancellation still works in the normal phases.
- Correctly save and restore `cancel_label` (used by the owner-draw button code) plus the window text and phase flag. Later phases (blocker list, disk space prompt, etc.) now always show the proper "Cancel" label.
- Added clear logging around package start, the actual installer launch + its exit code, successful completion, user skip, and processing finish. This makes future problems in this path easy to spot in logs without a memory dump.
- Minimized comments in the modified code. Where intent could have become unclear, naming + the added logs were used instead.

The change is isolated to the early package-install path that runs before the normal manifest download. All other update stages, rollback, blocker handling, etc. are untouched.