### PR TITLE
Speed up non-interactive runs: auto-accept dialogs immediately

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1175,7 +1175,7 @@ bool callbacks_impl::show_dialog(const DialogState &state)
 	prompting = true;
 
 	if (!params.interactive) {
-		log_info("Non-interactive mode: dialog will auto-%s after 30 seconds", state.default_accept ? "accept" : "decline");
+		log_info("Non-interactive mode: dialog will auto-%s immediately", state.default_accept ? "accept" : "decline");
 
 		if (!state.default_accept) {
 			should_cancel = true;
@@ -1183,7 +1183,10 @@ bool callbacks_impl::show_dialog(const DialogState &state)
 			return false;
 		}
 
-		SetTimer(frame, 2, 30000, &auto_accept_timer);
+		// Auto-accept as soon as the dialog is built and painted. The whole dialog
+		// code still runs (so tests catch future rendering bugs); we just don't wait.
+		// 1 is clamped to USER_TIMER_MINIMUM (~10ms) - long 30s waits stack up in tests.
+		SetTimer(frame, 2, 1, &auto_accept_timer);
 	}
 
 	text_panel_->set_text(state.content.c_str());

--- a/src/main.cc
+++ b/src/main.cc
@@ -1182,11 +1182,6 @@ bool callbacks_impl::show_dialog(const DialogState &state)
 			prompting = false;
 			return false;
 		}
-
-		// Auto-accept as soon as the dialog is built and painted. The whole dialog
-		// code still runs (so tests catch future rendering bugs); we just don't wait.
-		// 1 is clamped to USER_TIMER_MINIMUM (~10ms) - long 30s waits stack up in tests.
-		SetTimer(frame, 2, 1, &auto_accept_timer);
 	}
 
 	text_panel_->set_text(state.content.c_str());
@@ -1206,6 +1201,15 @@ bool callbacks_impl::show_dialog(const DialogState &state)
 
 	RedrawWindow(continue_button, NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
 	RedrawWindow(cancel_button, NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW);
+
+	if (!params.interactive) {
+		// Auto-accept once the dialog is fully built. Force a synchronous paint of the
+		// frame and its children first so the rendering/layout code is still exercised
+		// in tests, then arm a near-immediate timer (1 is clamped to USER_TIMER_MINIMUM,
+		// ~10ms) instead of waiting the long interactive timeout.
+		RedrawWindow(frame, NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+		SetTimer(frame, 2, 1, &auto_accept_timer);
+	}
 
 	bool result = run_message_loop(state.default_accept);
 


### PR DESCRIPTION
### Problem
In non-interactive mode (`--interactive 0`, used by the test suite), each prompt dialog (release-notes / update-available and the old-file-removal prompt) waits out a 30s auto-accept timer in `show_dialog`. Across a full test run that 30s-per-dialog stacks up and makes the suite slow.

### Solution
Keep the dialog fully functional but stop waiting:
- `show_dialog` still builds, lays out, and paints the entire dialog in non-interactive mode, so the rendering/layout code is still exercised and a future bug there will still crash the tests.
- The auto-accept `SetTimer` interval drops from `30000` to `1` (clamped to `USER_TIMER_MINIMUM`, ~10ms). The timer + `run_message_loop` + paint path is otherwise unchanged.
- `default_accept == false` dialogs already returned immediately and are untouched.

### Notes
- Applies to all non-interactive runs, so any silent/forced production update now auto-accepts these prompts near-instantly instead of after 30s.
- No behavior change for interactive (normal user) runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)