### PR TITLE
fix(crash): prevent AV in checkup_manifest path comparison

### DIFF
--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -10,6 +10,7 @@
 
 
 #include <fmt/format.h>
+#include <unordered_set>
 #include <aclapi.h>
 
 #include <fstream>
@@ -761,6 +762,8 @@ void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &v
 {
 	int max_threads = std::thread::hardware_concurrency();
 
+	std::unordered_set<std::string> seen_paths;
+
 	/* Generate the manifest for the current application directory */
 	fs::recursive_directory_iterator app_dir_iter(params->app_dir);
 	fs::recursive_directory_iterator end_iter{};
@@ -776,13 +779,13 @@ void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &v
 		if (fs::is_directory(entry_status))
 			continue;
 
-		if (std::find_if(local_manifest.begin(), local_manifest.end(),
-				 [&](std::pair<fs::path, std::string> &entry_pair) { return entry_pair.first == entry; }) != local_manifest.end())
+		std::string path_key = entry.u8string();
+		if (seen_paths.count(path_key))
 			continue;
+		seen_paths.insert(path_key);
 
 		local_manifest.emplace_back(entry, std::string(""));
 	}
-
 	std::vector<std::thread *> workers;
 
 	if (max_threads > local_manifest.size())

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -785,8 +785,7 @@ void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &v
 		if (fs::is_directory(entry_status))
 			continue;
 
-		std::string path_key = entry.u8string();
-		if (!seen_paths.emplace(std::move(path_key)).second)
+		if (!seen_paths.emplace(std::move(entry.u8string())).second)
 			continue;
 
 		local_manifest.emplace_back(entry, std::string(""));
@@ -807,7 +806,7 @@ void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &v
 		from = to;
 	}
 
-	for (auto &worker : workers) {
+	for (auto& worker : workers) {
 		if (worker.joinable())
 			worker.join();
 	}

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -807,7 +807,7 @@ void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &v
 		from = to;
 	}
 
-	for (auto worker : workers) {
+	for (auto &worker : workers) {
 		if (worker.joinable())
 			worker.join();
 	}

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -763,6 +763,12 @@ void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &v
 	int max_threads = std::thread::hardware_concurrency();
 
 	std::unordered_set<std::string> seen_paths;
+	
+	// Seed from existing entries so we do not add duplicates on re-entrant calls
+	// (e.g. when process_manifest_results is called repeatedly while waiting for blockers)
+	for (const auto& entry_pair : local_manifest) {
+		seen_paths.insert(entry_pair.first.u8string());
+	}
 
 	/* Generate the manifest for the current application directory */
 	fs::recursive_directory_iterator app_dir_iter(params->app_dir);

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -760,7 +760,7 @@ void update_client::checkup_files(struct blockers_map_t &blockers, struct blocke
 
 void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &virtualcam_blockers)
 {
-	int max_threads = std::thread::hardware_concurrency();
+	int max_threads = std::max(1, static_cast<int>(std::thread::hardware_concurrency()));
 
 	std::unordered_set<std::string> seen_paths;
 	
@@ -786,12 +786,12 @@ void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &v
 			continue;
 
 		std::string path_key = entry.u8string();
-		if (!seen_paths.emplace(path_key).second)
+		if (!seen_paths.emplace(std::move(path_key)).second)
 			continue;
 
 		local_manifest.emplace_back(entry, std::string(""));
 	}
-	std::vector<std::thread *> workers;
+	std::vector<std::thread> workers;
 
 	if (max_threads > local_manifest.size())
 		max_threads = static_cast<int>(local_manifest.size());
@@ -803,13 +803,13 @@ void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &v
 			to = local_manifest.size() * (i + 1) / max_threads;
 		else
 			to = local_manifest.size();
-		workers.push_back(new std::thread(&update_client::checkup_files, this, std::ref(blockers), std::ref(virtualcam_blockers), static_cast<int>(from), static_cast<int>(to)));
+		workers.emplace_back(&update_client::checkup_files, this, std::ref(blockers), std::ref(virtualcam_blockers), static_cast<int>(from), static_cast<int>(to));
 		from = to;
 	}
 
 	for (auto worker : workers) {
-		if (worker->joinable())
-			worker->join();
+		if (worker.joinable())
+			worker.join();
 	}
 
 	return;

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -786,9 +786,8 @@ void update_client::checkup_manifest(blockers_map_t &blockers, blockers_map_t &v
 			continue;
 
 		std::string path_key = entry.u8string();
-		if (seen_paths.count(path_key))
+		if (!seen_paths.emplace(path_key).second)
 			continue;
-		seen_paths.insert(path_key);
 
 		local_manifest.emplace_back(entry, std::string(""));
 	}


### PR DESCRIPTION
## Summary

Fixes a crash (`EXCEPTION_ACCESS_VIOLATION_READ` at 0x2) that occurs in `update_client::checkup_manifest` when comparing `fs::path` objects during directory scanning.

### Root Cause
The original deduplication logic used:
```cpp
std::find_if(..., [&](auto& p) { return p.first == entry; })
```
This calls `std::filesystem::path::operator==`, which can trigger an access violation inside the MSVC STL on certain Windows installations (especially with large directories like Streamlabs OBS containing 2000+ files).

### Changes
- Replaced unsafe `fs::path::operator==` comparison with `std::unordered_set<std::string>` using `u8string()` keys
- Seed the set from existing `local_manifest` entries to preserve correct re-entrant behavior during blocker polling
- Store worker threads by value (`std::vector<std::thread>`) instead of raw pointers to eliminate leaks and improve exception safety
- Clamp `std::thread::hardware_concurrency()` result to at least 1
- Use `emplace(std::move(...)).second` for efficient insertion

### Testing
- The change was made while investigating a real Sentry crash report
- All review feedback from Copilot has been addressed