### PR TITLE
Redist install: quiet failures, report to Sentry, fix detection & UI

### DIFF
--- a/src/crash-reporter.cc
+++ b/src/crash-reporter.cc
@@ -539,6 +539,14 @@ void save_exit_error(const std::string &category, const std::string &reason) noe
 	}
 }
 
+void report_handled_error(const std::string &category, const std::string &reason) noexcept
+{
+	// handle_exit() is skipped on the success path, so send now rather than buffering.
+	save_exit_error(category, reason);
+	std::string report = prepare_crash_report(nullptr, "");
+	send_crash_to_sentry_sync(report, false);
+}
+
 void print_stacktrace_sym(CONTEXT *ctx, std::ostringstream &report_stream) noexcept
 {
 	BOOL result;

--- a/src/crash-reporter.cc
+++ b/src/crash-reporter.cc
@@ -307,6 +307,12 @@ int send_crash_to_sentry_sync(const std::string &report_json, bool send_minidump
 				++endpoint_iterator;
 				continue;
 			}
+
+			// Bound blocking send/recv (TLS handshake and the POST) so a stalled network can't hang the caller.
+			DWORD io_timeout_ms = 5000;
+			::setsockopt(ssl_socket.lowest_layer().native_handle(), SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char *>(&io_timeout_ms), sizeof(io_timeout_ms));
+			::setsockopt(ssl_socket.lowest_layer().native_handle(), SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char *>(&io_timeout_ms), sizeof(io_timeout_ms));
+
 			ssl_socket.lowest_layer().connect(endpoint_iterator->endpoint(), error);
 			if (error) {
 				++endpoint_iterator;

--- a/src/crash-reporter.cc
+++ b/src/crash-reporter.cc
@@ -100,8 +100,8 @@ std::string prepare_crash_report(struct _EXCEPTION_POINTERS *ExceptionInfo, std:
 		json_report << "	}]}, ";
 	} else if (!ExceptionInfo && minidump_result.size() == 0) {
 		json_report << "	\"exception\": {\"values\":[{";
-		json_report << "		\"type\": \"" << last_error_category << "\", ";
-		json_report << "		\"value\": \"" << last_error_reason << "\" ";
+		json_report << "		\"type\": \"" << escapeJsonString(last_error_category) << "\", ";
+		json_report << "		\"value\": \"" << escapeJsonString(last_error_reason) << "\" ";
 		json_report << "	}]}, ";
 	}
 	json_report << "	\"tags\": { ";

--- a/src/crash-reporter.cc
+++ b/src/crash-reporter.cc
@@ -12,6 +12,7 @@
 #include "utils.hpp"
 
 #include <memory>
+#include <thread>
 
 #include "crash-reporter.hpp"
 #include "update-parameters.hpp"
@@ -547,10 +548,15 @@ void save_exit_error(const std::string &category, const std::string &reason) noe
 
 void report_handled_error(const std::string &category, const std::string &reason) noexcept
 {
-	// handle_exit() is skipped on the success path, so send now rather than buffering.
+	// handle_exit() is skipped on the success path, so send now instead of buffering; do it
+	// off-thread so a slow/hung connect can't block the updater (best-effort).
 	save_exit_error(category, reason);
 	std::string report = prepare_crash_report(nullptr, "");
-	send_crash_to_sentry_sync(report, false);
+	try {
+		std::thread([report]() { send_crash_to_sentry_sync(report, false); }).detach();
+	} catch (...) {
+		send_crash_to_sentry_sync(report, false);
+	}
 }
 
 void print_stacktrace_sym(CONTEXT *ctx, std::ostringstream &report_stream) noexcept

--- a/src/crash-reporter.hpp
+++ b/src/crash-reporter.hpp
@@ -3,4 +3,5 @@
 void setup_crash_reporting();
 void handle_exit() noexcept;
 void save_exit_error(const std::string &category, const std::string &reason) noexcept;
+void report_handled_error(const std::string &category, const std::string &reason) noexcept;
 bool is_launched_by_explorer();

--- a/src/crash-reporter.hpp
+++ b/src/crash-reporter.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 void setup_crash_reporting();
 void handle_exit() noexcept;
 void save_exit_error(const std::string &category, const std::string &reason) noexcept;

--- a/src/main.cc
+++ b/src/main.cc
@@ -838,14 +838,14 @@ void callbacks_impl::installer_run_file(const std::string &packageName, const st
 		case ERROR_PRODUCT_VERSION: // 1638: a newer redist is already installed
 		case ERROR_INSTALL_USEREXIT:
 		case ERROR_CANCELLED:
-			log_info("installer_run_file: '%s' skipped, benign exit code %d", packageName.c_str(), dwExitCode);
+			log_info("installer_run_file: '%s' skipped, benign exit code %lu", packageName.c_str(), dwExitCode);
 			break;
 		default:
 			installer_package_failed(packageName, "exit code " + std::to_string(dwExitCode));
 			break;
 		}
 
-		log_info("installer_run_file finished with error %d", dwExitCode);
+		log_info("installer_run_file finished with exit code %lu", dwExitCode);
 	}
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -495,9 +495,12 @@ void callbacks_impl::repostionUI()
 		SetWindowPos(progress_worker, 0, s_padding, progress_top, main_w, s_basic_height, SWP_ASYNCWINDOWPOS);
 	if (buttons_top >= 0) {
 		int button_left = main_w + s_padding - s_button_width;
+		// Right-align cancel when it's the only visible button (the "Skip" during package install).
+		bool primary_visible = IsWindowVisible(continue_button) || IsWindowVisible(kill_button);
+		int cancel_left = primary_visible ? (button_left - s_button_width - s_padding) : button_left;
 		SetWindowPos(continue_button, 0, button_left, buttons_top, s_button_width, s_basic_height, SWP_ASYNCWINDOWPOS);
 		SetWindowPos(kill_button, 0, button_left, buttons_top, s_button_width, s_basic_height, SWP_ASYNCWINDOWPOS);
-		SetWindowPos(cancel_button, 0, button_left - s_button_width - s_padding, buttons_top, s_button_width, s_basic_height, SWP_ASYNCWINDOWPOS);
+		SetWindowPos(cancel_button, 0, cancel_left, buttons_top, s_button_width, s_basic_height, SWP_ASYNCWINDOWPOS);
 		//reapply rounded regions at scaled size
 		int cRounding = ScaleDPI(4, current_dpi);
 		HRGN rgn = CreateRoundRectRgn(0, 0, s_button_width, s_basic_height, cRounding, cRounding);
@@ -728,7 +731,7 @@ void callbacks_impl::installer_download_start(const std::string &packageName)
 	installer_download_progress(0);
 
 	std::wstring downloading_label = ConvertToUtf16WS(boost::locale::translate("Downloading required component: "));
-	downloading_label += fmt::to_wstring(packageName) + L"...";
+	downloading_label += ConvertToUtf16WS(packageName) + L"...";
 
 	HDC hdc = GetDC(frame);
 	HFONT hfontOld = (HFONT)SelectObject(hdc, main_font);
@@ -777,16 +780,9 @@ void callbacks_impl::installer_package_failed(const std::string &packageName, co
 {
 	restore_cancel_button_text();
 
-	if (message.empty())
-		MessageBoxA(frame, ("WARNING: Streamlabs Desktop was unable to download/install the required '" + packageName + "' package.").c_str(),
-			    "Package Installation", MB_OK | MB_ICONWARNING);
-	else
-		MessageBoxA(
-			frame,
-			("WARNING: Streamlabs Desktop was unable to download/install the required '" + packageName + "' package.\nError: " + message).c_str(),
-			"Package Installation", MB_OK | MB_ICONWARNING);
-
-	log_info(("installer_package_failed, message = " + message).c_str());
+	// Redist isn't required for the update, so report silently instead of blocking the user.
+	log_error(("installer_package_failed, package = " + packageName + ", message = " + message).c_str());
+	report_handled_error("PackageInstallFailure", packageName + (message.empty() ? "" : (": " + message)));
 }
 
 void callbacks_impl::installer_run_file(const std::string &packageName, const std::string &startParams, const std::string &rawFileBin)
@@ -839,12 +835,17 @@ void callbacks_impl::installer_run_file(const std::string &packageName, const st
 				//MessageBoxA(frame, "A restart is required to complete the update.", "Package Installation", MB_OK | MB_ICONWARNING);
 			}
 			break;
+		case ERROR_PRODUCT_VERSION: // 1638: a newer redist is already installed
+		case ERROR_INSTALL_USEREXIT:
+		case ERROR_CANCELLED:
+			log_info("installer_run_file: '%s' skipped, benign exit code %d", packageName.c_str(), dwExitCode);
+			break;
 		default:
-			installer_package_failed(packageName, "");
+			installer_package_failed(packageName, "exit code " + std::to_string(dwExitCode));
 			break;
 		}
 
-		log_info("installer_run_file failed with error %d", dwExitCode);
+		log_info("installer_run_file finished with error %d", dwExitCode);
 	}
 }
 
@@ -1630,7 +1631,7 @@ BOOL HasInstalled_VC_redistx64()
 		boost::split(versions, version, boost::is_any_of("."));
 
 		// "Version"="14.50.35719.0"
-		if (versions.size() == 3) {
+		if (versions.size() >= 3) {
 			if (_wtoi(versions[0].c_str()) < 14)
 				return FALSE;
 


### PR DESCRIPTION
﻿Restored "install VC++ redist before update" was surfacing a confusing warning dialog on failure. This quiets it and fixes the root cause.

- Drop the failure MessageBox; report genuine failures to Sentry (non-fatal, `PackageInstallFailure`)
- Treat benign exit codes 1638/1602/1223 as success
- Fix `HasInstalled_VC_redistx64` version parse (`== 3` -> `>= 3`) so redist is skipped when already installed
- Download UI: show component name; right-align the lone Skip button


