### PR TITLE
Shrink updater binary: /OPT:REF,ICF + trim boost-iostreams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,17 +76,18 @@ target_compile_options(slobs-updater
 	$<IF:$<CONFIG:Debug>,-MTd,-MT>
 	-W3 -Zi
 	-bigobj
-	# per-function/data COMDATs so /OPT:REF,ICF can drop the unused ones
-	-Gy -Gw
+	# per-function/data COMDATs so /OPT:REF,ICF can drop the unused ones (non-Debug only)
+	$<$<NOT:$<CONFIG:Debug>>:-Gy>
+	$<$<NOT:$<CONFIG:Debug>>:-Gw>
 )
 
 target_link_options(slobs-updater
 	PRIVATE
 	/DEBUG
-	# /DEBUG defaults /OPT to NOREF/NOICF; re-enable to strip static-lib dead code (PDB kept)
-	/OPT:REF
-	/OPT:ICF
-	/INCREMENTAL:NO
+	# /DEBUG defaults /OPT to NOREF/NOICF; re-enable for non-Debug to strip static-lib dead code (PDB kept)
+	$<$<NOT:$<CONFIG:Debug>>:/OPT:REF>
+	$<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>
+	$<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>
 )
 
 set_property(TARGET slobs-updater PROPERTY CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,17 @@ target_compile_options(slobs-updater
 	$<IF:$<CONFIG:Debug>,-MTd,-MT>
 	-W3 -Zi
 	-bigobj
+	# per-function/data COMDATs so /OPT:REF,ICF can drop the unused ones
+	-Gy -Gw
 )
 
 target_link_options(slobs-updater
 	PRIVATE
 	/DEBUG
+	# /DEBUG defaults /OPT to NOREF/NOICF; re-enable to strip static-lib dead code (PDB kept)
+	/OPT:REF
+	/OPT:ICF
+	/INCREMENTAL:NO
 )
 
 set_property(TARGET slobs-updater PROPERTY CXX_STANDARD 17)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,7 @@
     "boost-beast",
     "boost-bind",
     "boost-exception",
-    "boost-iostreams",
+    { "name": "boost-iostreams", "default-features": false, "features": ["zlib"] },
     "boost-locale",
     "boost-system"
   ],


### PR DESCRIPTION
﻿The vcpkg static migration grew `slobs-updater.exe` from ~6MB to **12,094,464 bytes (~11.5MB)**. Investigation (no ICU involved; debug info is in the separate PDB) found the growth is static OpenSSL + Boost, **amplified because `/DEBUG` left `/OPT:REF`/`/OPT:ICF` off** (no dead-code stripping), plus `boost-iostreams` pulling unused zstd/lzma/bzip2.

This is a config-only first pass (no source changes):

- Link `/OPT:REF /OPT:ICF /INCREMENTAL:NO` + compile `/Gy /Gw` to strip static-lib dead code (PDB kept).
- Trim `boost-iostreams` to the `zlib` feature (drop unused zstd/lzma/bzip2).

Measure after build: compare the exe against the 12,094,464-byte baseline. Deeper cuts (iostreams -> raw zlib+EVP, or WinHTTP+SChannel to drop OpenSSL) are deferred follow-ups gated on the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
