### PR TITLE
Drop boost-algorithm/bind/exception for std analogs

### DIFF
--- a/src/crash-reporter.cc
+++ b/src/crash-reporter.cc
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <fstream>
 #include <iomanip>
-#include <boost/bind/bind.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl/error.hpp>
 #include <boost/asio/ssl/stream.hpp>

--- a/src/crash-reporter.cc
+++ b/src/crash-reporter.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <list>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl/error.hpp>
 #include <boost/asio/ssl/stream.hpp>

--- a/src/main.cc
+++ b/src/main.cc
@@ -21,7 +21,6 @@
 #include <thread>
 #include <fstream>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/locale.hpp>
 
 #include <json.hpp>
@@ -1628,7 +1627,12 @@ BOOL HasInstalled_VC_redistx64()
 
 	if (ret == ERROR_SUCCESS) {
 		std::vector<std::wstring> versions;
-		boost::split(versions, version, boost::is_any_of("."));
+		for (size_t start = 0, dot;; start = dot + 1) {
+			dot = version.find(L'.', start);
+			versions.push_back(version.substr(start, dot - start));
+			if (dot == std::wstring::npos)
+				break;
+		}
 
 		// "Version"="14.50.35719.0"
 		if (versions.size() >= 3) {

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -417,8 +417,8 @@ void update_client::install_package(const std::string &packageName, std::string 
 	boost::system::error_code error;
 
 	std::string domainName;
-	boost::replace_all(url, "https://", "");
-	boost::replace_all(url, "http://", "");
+	replace_all(url, "https://", "");
+	replace_all(url, "http://", "");
 
 	for (size_t itr = 0; itr < url.size(); ++itr) {
 		if (url[itr] == '/' || url[itr] == '\\')
@@ -895,7 +895,7 @@ void update_client::process_manifest_results()
 			};
 
 			wait_for_blockers.expires_after(std::chrono::seconds(1));
-			wait_for_blockers.async_wait(boost::bind(&update_client::process_manifest_results, this));
+			wait_for_blockers.async_wait([this](const boost::system::error_code &) { process_manifest_results(); });
 			return;
 		}
 
@@ -959,7 +959,7 @@ void update_client::process_manifest_results()
 			};
 
 			wait_for_blockers.expires_after(std::chrono::seconds(1));
-			wait_for_blockers.async_wait(boost::bind(&update_client::process_manifest_results, this));
+			wait_for_blockers.async_wait([this](const boost::system::error_code &) { process_manifest_results(); });
 			return;
 		} else {
 			this->blocker_events->blocker_wait_complete();
@@ -1096,7 +1096,7 @@ void update_client::handle_manifest_result(std::shared_ptr<manifest_request<mani
 	this->downloader_events->downloader_preparing(true);
 
 	wait_for_blockers.expires_after(std::chrono::seconds(3));
-	wait_for_blockers.async_wait(boost::bind(&update_client::process_manifest_results, this));
+	wait_for_blockers.async_wait([this](const boost::system::error_code &) { process_manifest_results(); });
 
 	/* let time for Streamlabs Desktop process to quit and make files available for update */
 	handle_pids();
@@ -1202,23 +1202,23 @@ void update_client::next_manifest_entry(int index)
 
 template<> void update_http_request<manifest_body, false>::handle_download_canceled()
 {
-	boost::asio::post(client_ctx->io_ctx, boost::bind(&update_client::handle_manifest_download_canceled, client_ctx, shared_from_this()));
+	boost::asio::post(client_ctx->io_ctx, [self = shared_from_this()] { self->client_ctx->handle_manifest_download_canceled(self); });
 }
 
 template<> void update_http_request<http::dynamic_body, true>::handle_download_canceled()
 {
-	boost::asio::post(client_ctx->io_ctx, boost::bind(&update_client::handle_file_download_canceled, client_ctx, shared_from_this()));
+	boost::asio::post(client_ctx->io_ctx, [self = shared_from_this()] { self->client_ctx->handle_file_download_canceled(self); });
 }
 
 template<> void update_http_request<manifest_body, false>::handle_download_error(const boost::system::error_code &error, const std::string &str)
 {
-	boost::asio::post(client_ctx->io_ctx, boost::bind(&update_client::handle_manifest_download_error, client_ctx, shared_from_this(), error, str));
+	boost::asio::post(client_ctx->io_ctx, [self = shared_from_this(), error, str] { self->client_ctx->handle_manifest_download_error(self, error, str); });
 }
 
 template<> void update_http_request<http::dynamic_body, true>::handle_download_error(const boost::system::error_code &error, const std::string &str)
 {
 	try {
-		boost::asio::post(client_ctx->io_ctx, boost::bind(&update_client::handle_file_download_error, client_ctx, shared_from_this(), error, str));
+		boost::asio::post(client_ctx->io_ctx, [self = shared_from_this(), error, str] { self->client_ctx->handle_file_download_error(self, error, str); });
 	} catch (const std::bad_weak_ptr &) {
 		log_warn("Skipping file download error callback; request is already being torn down");
 	}
@@ -1234,7 +1234,7 @@ template<> void update_http_request<http::dynamic_body, true>::handle_result(upd
 {
 	try {
 		boost::asio::post(client_ctx->io_ctx,
-				  boost::bind(&update_client::handle_file_result, client_ctx, shared_from_this(), file_ctx, this->worker_id));
+				  [self = shared_from_this(), file_ctx, id = this->worker_id] { self->client_ctx->handle_file_result(self, file_ctx, id); });
 	} catch (const std::bad_weak_ptr &) {
 		log_warn("Skipping file result callback; request is already being torn down");
 		delete file_ctx; // handle_file_result would have owned this; free it since the post didn't happen

--- a/src/update-http-request.hpp
+++ b/src/update-http-request.hpp
@@ -9,13 +9,10 @@
 #include <boost/asio/ssl/error.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/beast.hpp>
-#include <boost/bind/bind.hpp>
 #include <boost/iostreams/chain.hpp>
 #include <boost/iostreams/device/file_descriptor.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/traits.hpp>
-#include <boost/exception/all.hpp>
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/locale.hpp>
 
 namespace asio = boost::asio;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <map>
 
 #include "logger/log.h"
 #include "checksum-filters.hpp"

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -5,12 +5,9 @@
 #include <iostream>
 #include <sstream>
 
-#include <boost/exception/all.hpp>
-
 #include "logger/log.h"
 #include "checksum-filters.hpp"
 #include <openssl/evp.h>
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/locale.hpp>
 #include <filesystem>
 
@@ -261,6 +258,14 @@ std::string urlencode(const std::string &url)
 	return ostream.str();
 }
 
+void replace_all(std::string &s, std::string_view from, std::string_view to)
+{
+	if (from.empty())
+		return;
+	for (size_t pos = 0; (pos = s.find(from, pos)) != std::string::npos; pos += to.size())
+		s.replace(pos, from.size(), to);
+}
+
 std::string fixup_uri(const std::string &source)
 {
 	std::string result(source);
@@ -269,10 +274,10 @@ std::string fixup_uri(const std::string &source)
 							  {')', "%29"}, {'*', "%2A"}, {'+', "%2B"}, {',', "%2C"}, {':', "%3A"},  {';', "%3B"},
 							  {'<', "%3C"}, {'=', "%3E"}, {'?', "%3F"}, {'@', "%40"}, {'[', "%5B"},  {']', "%5D"},
 							  {'^', "%5E"}, {'`', "%60"}, {'{', "%7B"}, {'|', "%7C"}, {'}', "%7D"},  {'~', "%7E"}};
-	boost::algorithm::replace_all(result, "\\", "/");
-	boost::algorithm::replace_all(result, "%", "%25");
+	replace_all(result, "\\", "/");
+	replace_all(result, "%", "%25");
 	for (const auto &pair : urlEncodeMap) {
-		boost::algorithm::replace_all(result, std::string(1, pair.first), pair.second);
+		replace_all(result, std::string(1, pair.first), pair.second);
 	}
 
 	return result;
@@ -290,11 +295,11 @@ std::string unfixup_uri(const std::string &source)
 
 	// Iterating over each encoded sequence in the map
 	for (const auto &pair : urlDecodeMap) {
-		boost::algorithm::replace_all(result, pair.first, std::string(1, pair.second));
+		replace_all(result, pair.first, std::string(1, pair.second));
 	}
 
 	// Replacing encoded backslash
-	boost::algorithm::replace_all(result, "/", "\\");
+	replace_all(result, "/", "\\");
 
 	return result;
 }
@@ -304,8 +309,6 @@ std::string calculate_files_checksum_safe(const fs::path &path)
 	std::string checksum = "";
 	try {
 		checksum = calculate_files_checksum(path);
-	} catch (const boost::exception &e) {
-		log_warn("Failed to calculate checksum of local file. Exception: %s", boost::diagnostic_information(e).c_str());
 	} catch (const std::exception &e) {
 		log_warn("Failed to calculate checksum of local file. std::exception: %s", e.what());
 	} catch (...) {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -4,6 +4,8 @@
 #include <filesystem>
 #include <unordered_map>
 #include <vector>
+#include <string>
+#include <string_view>
 
 #ifndef USER_DEFAULT_SCREEN_DPI
 #define USER_DEFAULT_SCREEN_DPI 96
@@ -50,6 +52,8 @@ std::string unfixup_uri(const std::string &source);
 std::string fixup_uri(const std::string &source);
 std::string encimpl(std::string::value_type v);
 std::string urlencode(const std::string &url);
+
+void replace_all(std::string &s, std::string_view from, std::string_view to);
 
 std::string calculate_files_checksum(const fs::path &path);
 std::string calculate_files_checksum_safe(const fs::path &path);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,11 +4,8 @@
   "dependencies": [
     "openssl",
     "zlib",
-    "boost-algorithm",
     { "name": "boost-asio", "default-features": false },
     "boost-beast",
-    "boost-bind",
-    "boost-exception",
     { "name": "boost-iostreams", "default-features": false, "features": ["zlib"] },
     "boost-locale",
     "boost-system"


### PR DESCRIPTION
﻿Reduces the external Boost dependency surface by moving three header-only Boost libs to standard C++. Dependency reduction, not size — no behavior change, `CMakeLists.txt` unchanged (these were header-only, not `find_package` components). Declared deps drop 10 → 7.

- **boost-algorithm** → a small `replace_all()` helper in `utils` + a manual tokenizer for the redist version parse.
- **boost-bind** → lambdas for the asio handlers (matches existing style; `self = shared_from_this()` keeps the request alive on posted callbacks). Also removes a dead `boost/bind` include.
- **boost-exception** → the one catch was dead/defensive (checksum uses `std::ifstream` + OpenSSL EVP); the `std::exception` handler already covers it. Removes 2 includes (1 dead).

`boost::throw_exception` in the vendored iostreams gzip/zlib is a different, transitive port and is untouched. asio/beast/system/locale/iostreams stay.

Deferred (bigger, not std analogs): boost-iostreams → raw zlib + OpenSSL EVP; boost-locale → `.mo` parser; asio/beast/system → WinHTTP+SChannel.
