### PR TITLE
Fixes a crash in the updater's parallel checksum download workers

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -980,18 +980,19 @@ int callbacks_impl::disk_space_waiting_for(const std::wstring &app_dir, size_t a
 
 		std::transform(app_disk_name.begin(), app_disk_name.end(), app_disk_name.begin(), ::toupper);
 		std::transform(temp_disk_name.begin(), temp_disk_name.end(), temp_disk_name.begin(), ::toupper);
-		std::wostringstream processes_list;
-		processes_list.precision(2);
-		processes_list << std::fixed;
+		std::wostringstream free_space_text;
+		free_space_text.imbue(std::locale::classic());
+		free_space_text.precision(2);
+		free_space_text << std::fixed;
 
 		if (app_disk_name != temp_disk_name) {
-			processes_list << L"" << app_disk_name << L"[APP] " << app_dir_free_space / 1024.0 / 1024.0 << L" Mb free";
-			processes_list << L"\r\n" << L"" << temp_disk_name << L"[TEMP]" << temp_dir_free_space / 1024.0 / 1024.0 << L" Mb free";
+			free_space_text << app_disk_name << L"[APP] " << app_dir_free_space / 1024.0 / 1024.0 << L" Mb free";
+			free_space_text << L"\r\n" << temp_disk_name << L"[TEMP]" << temp_dir_free_space / 1024.0 / 1024.0 << L" Mb free";
 		} else {
-			processes_list << L"" << app_disk_name << L" " << app_dir_free_space / 1024.0 / 1024.0 << L" Mb free";
+			free_space_text << app_disk_name << L" " << app_dir_free_space / 1024.0 / 1024.0 << L" Mb free";
 		}
 		if (active_panel)
-			active_panel->set_text(processes_list.str().c_str());
+			active_panel->set_text(free_space_text.str().c_str());
 	}
 	return ret;
 }

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -1023,6 +1023,7 @@ void update_client::start_downloading_files()
 		++this->active_workers;
 
 		auto request_ctx = std::make_shared<file_request<http::dynamic_body>>(this, fixup_uri((*this->manifest_iterator).first) + ".gz", i);
+		request_ctx->expected_hash = (*this->manifest_iterator).second.hash_sum;
 
 		request_ctx->start_connect();
 
@@ -1130,18 +1131,23 @@ update_file_t::update_file_t(const fs::path &file_path) : file_path(file_path), 
 
 void update_client::handle_file_result(std::shared_ptr<file_request<http::dynamic_body>> request_ctx, update_file_t *file_ctx, int index)
 {
-	(void)request_ctx; // held only to keep the request alive across the async hop
 	auto &filter = file_ctx->checksum_filter;
 
 	try {
 		file_ctx->output_chain.reset();
 
-		std::ostringstream hex_digest;
-
-		hex_digest << std::nouppercase << std::setfill('0') << std::hex;
-
+		static const char hex_chars[] = "0123456789abcdef";
+		std::string hex_digest;
+		hex_digest.reserve(SHA256_DIGEST_LENGTH * 2);
 		for (int i = 0; i < SHA256_DIGEST_LENGTH; ++i) {
-			hex_digest << std::setw(2) << static_cast<unsigned int>(filter.digest[i]);
+			hex_digest.push_back(hex_chars[filter.digest[i] >> 4]);
+			hex_digest.push_back(hex_chars[filter.digest[i] & 0x0F]);
+		}
+
+		const std::string &expected = request_ctx->expected_hash;
+		if (!expected.empty() && hex_digest != expected) {
+			log_error("Downloaded file checksum mismatch for %s, expected %s, got %s", request_ctx->target.c_str(), expected.c_str(),
+				  hex_digest.c_str());
 		}
 	} catch (...) {
 	}
@@ -1186,6 +1192,7 @@ void update_client::next_manifest_entry(int index)
 				manifest_lock.unlock();
 
 				auto request_ctx = std::make_shared<file_request<http::dynamic_body>>(this, fixup_uri(entry.first) + ".gz", index);
+				request_ctx->expected_hash = entry.second.hash_sum;
 
 				request_ctx->start_connect();
 			}

--- a/src/update-http-request.hpp
+++ b/src/update-http-request.hpp
@@ -36,6 +36,7 @@ template<class Body, bool IncludeVersion> struct update_http_request : public st
 	int worker_id;
 	update_client *client_ctx;
 	std::string target;
+	std::string expected_hash;
 	std::string used_cdn_node_address;
 
 	/* We used to support http and then I realized

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -237,9 +237,12 @@ std::string encimpl(std::string::value_type v)
 	if (isascii(v))
 		return std::string() + v;
 
-	std::ostringstream enc;
-	enc << '%' << std::setw(2) << std::setfill('0') << std::hex << std::uppercase << int(static_cast<unsigned char>(v));
-	return enc.str();
+	static const char hex_chars[] = "0123456789ABCDEF";
+	unsigned char uc = static_cast<unsigned char>(v);
+	std::string enc = "%";
+	enc.push_back(hex_chars[uc >> 4]);
+	enc.push_back(hex_chars[uc & 0x0F]);
+	return enc;
 }
 
 std::string urlencode(const std::string &url)
@@ -320,7 +323,7 @@ std::string calculate_files_checksum_safe(const fs::path &path)
 
 std::string calculate_files_checksum(const fs::path &path)
 {
-	std::ostringstream hex_digest;
+	std::string hex_digest;
 	unsigned char hash[SHA256_DIGEST_LENGTH] = {0};
 
 	std::ifstream file(path, std::ios::in | std::ios::binary);
@@ -357,14 +360,15 @@ std::string calculate_files_checksum(const fs::path &path)
 
 		file.close();
 
-		hex_digest << std::nouppercase << std::setfill('0') << std::hex;
-
+		static const char hex_chars[] = "0123456789abcdef";
+		hex_digest.reserve(SHA256_DIGEST_LENGTH * 2);
 		for (int i = 0; i < SHA256_DIGEST_LENGTH; ++i) {
-			hex_digest << std::setw(2) << static_cast<unsigned int>(hash[i]);
+			hex_digest.push_back(hex_chars[hash[i] >> 4]);
+			hex_digest.push_back(hex_chars[hash[i] & 0x0F]);
 		}
 	}
 
-	return hex_digest.str();
+	return hex_digest;
 }
 
 std::vector<char> get_messages_callback(std::string const &file_name, std::string const &encoding)


### PR DESCRIPTION
## Why
The app installs a boost::locale locale as the *global* locale (for translated UI strings). Side effect: every std::ostream picks up boost's number-formatting facet, which re-imbues a fresh stream per number. Doing that concurrently across the worker threads races the MSVC CRT locale tables (`_lock_locales` /`__acrt_LocaleNameToLCID`) → `EXCEPTION_ACCESS_VIOLATION_READ`. Reported in `calculate_files_checksum`.

## Changes
- Replace stream-based hex/number formatting with manual formatting on the worker paths: `calculate_files_checksum`, `handle_file_result`, `encimpl`.
- Wire up download integrity: thread the expected manifest hash to the request and compare it against the downloaded file's SHA-256 (was computed and thrown away); log on mismatch.
- Harden disk-space formatting in `main.cc` with `imbue(std::locale::classic())`.

## Notes
- Hex/number output is byte-identical; the disk-space decimal separator is now locale-independent `.`.
- Follow-up (separate PR): stop making boost::locale the global locale — imbue only on the translate path — which also covers the remaining `crash-reporter.cc`   instance.
