### PR TITLE
Confine boost::locale to messages; share one locale-safe hex encoder

### DIFF
--- a/src/crash-reporter.cc
+++ b/src/crash-reporter.cc
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <iomanip>
 #include <list>
+#include <locale>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl/error.hpp>
 #include <boost/asio/ssl/stream.hpp>
@@ -80,6 +81,9 @@ std::string GetWindowsVersionString();
 std::string prepare_crash_report(struct _EXCEPTION_POINTERS *ExceptionInfo, std::string minidump_result) noexcept
 {
 	std::ostringstream json_report;
+	/* Crash handler runs on the faulting thread (possibly a worker) and must not
+	 * depend on the process locale being set up; format everything with classic. */
+	json_report.imbue(std::locale::classic());
 
 	json_report << "{";
 	json_report << "	\"event_id\": \"" << get_uuid() << "\", ";
@@ -168,6 +172,7 @@ std::string GetWindowsVersionString()
 	VS_FIXEDFILEINFO *pFixedFileInfo;
 	UINT uLen;
 	std::ostringstream oss;
+	oss.imbue(std::locale::classic());
 
 	DWORD dwSize = GetFileVersionInfoSize(TEXT("kernel32.dll"), &dwHandle);
 	BYTE *pBuffer = new BYTE[dwSize];

--- a/src/update-client.cc
+++ b/src/update-client.cc
@@ -1136,13 +1136,7 @@ void update_client::handle_file_result(std::shared_ptr<file_request<http::dynami
 	try {
 		file_ctx->output_chain.reset();
 
-		static const char hex_chars[] = "0123456789abcdef";
-		std::string hex_digest;
-		hex_digest.reserve(SHA256_DIGEST_LENGTH * 2);
-		for (int i = 0; i < SHA256_DIGEST_LENGTH; ++i) {
-			hex_digest.push_back(hex_chars[filter.digest[i] >> 4]);
-			hex_digest.push_back(hex_chars[filter.digest[i] & 0x0F]);
-		}
+		std::string hex_digest = to_hex(filter.digest, SHA256_DIGEST_LENGTH);
 
 		const std::string &expected = request_ctx->expected_hash;
 		if (!expected.empty() && hex_digest != expected) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -249,16 +249,19 @@ std::string to_hex(const unsigned char *data, size_t len, bool uppercase)
 
 std::string encimpl(std::string::value_type v)
 {
-	if (isascii(v))
-		return std::string() + v;
+	const unsigned char uc = static_cast<unsigned char>(v);
 
-	unsigned char uc = static_cast<unsigned char>(v);
+	if (isascii(uc))
+		return std::string(1, v);
+
 	return "%" + to_hex(&uc, 1, true);
 }
 
 std::string urlencode(const std::string &url)
 {
 	std::string result;
+	result.reserve(url.size());
+
 	for (char c : url)
 		result += encimpl(c);
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -232,34 +232,37 @@ fs::path prepare_file_path(const fs::path &base, const std::string &target)
 	return file_path;
 }
 
+std::string to_hex(const unsigned char *data, size_t len, bool uppercase)
+{
+	static const char lower[] = "0123456789abcdef";
+	static const char upper[] = "0123456789ABCDEF";
+	const char *hex = uppercase ? upper : lower;
+
+	std::string out;
+	out.reserve(len * 2);
+	for (size_t i = 0; i < len; ++i) {
+		out.push_back(hex[data[i] >> 4]);
+		out.push_back(hex[data[i] & 0x0F]);
+	}
+	return out;
+}
+
 std::string encimpl(std::string::value_type v)
 {
 	if (isascii(v))
 		return std::string() + v;
 
-	static const char hex_chars[] = "0123456789ABCDEF";
 	unsigned char uc = static_cast<unsigned char>(v);
-	std::string enc = "%";
-	enc.push_back(hex_chars[uc >> 4]);
-	enc.push_back(hex_chars[uc & 0x0F]);
-	return enc;
+	return "%" + to_hex(&uc, 1, true);
 }
 
 std::string urlencode(const std::string &url)
 {
-	const std::string::const_iterator start = url.begin();
+	std::string result;
+	for (char c : url)
+		result += encimpl(c);
 
-	std::vector<std::string> qstrs;
-
-	std::transform(start, url.end(), std::back_inserter(qstrs), encimpl);
-
-	std::ostringstream ostream;
-
-	for (auto const &i : qstrs) {
-		ostream << i;
-	}
-
-	return ostream.str();
+	return result;
 }
 
 void replace_all(std::string &s, std::string_view from, std::string_view to)
@@ -360,12 +363,7 @@ std::string calculate_files_checksum(const fs::path &path)
 
 		file.close();
 
-		static const char hex_chars[] = "0123456789abcdef";
-		hex_digest.reserve(SHA256_DIGEST_LENGTH * 2);
-		for (int i = 0; i < SHA256_DIGEST_LENGTH; ++i) {
-			hex_digest.push_back(hex_chars[hash[i] >> 4]);
-			hex_digest.push_back(hex_chars[hash[i] & 0x0F]);
-		}
+		hex_digest = to_hex(hash, SHA256_DIGEST_LENGTH);
 	}
 
 	return hex_digest;
@@ -433,5 +431,12 @@ void setup_locale()
 	info.variant = properties.variant();
 
 	std::locale real_locale(base_locale, blg::create_messages_facet<char>(info));
+
+	/* Confine boost::locale to message translation only. Keep classic (C) numeric
+	 * facets so std stream/number formatting stays locale-independent and thread-safe:
+	 * boost's numeric facets triggered an MSVC CRT locale race when download/checksum
+	 * workers formatted numbers concurrently. */
+	real_locale = std::locale(real_locale, std::locale::classic(), std::locale::numeric);
+
 	std::locale::global(real_locale);
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -53,6 +53,10 @@ std::string fixup_uri(const std::string &source);
 std::string encimpl(std::string::value_type v);
 std::string urlencode(const std::string &url);
 
+/* Locale-independent, thread-safe hex encoding — avoids std stream number
+ * formatting, which inherits the global locale (see setup_locale). */
+std::string to_hex(const unsigned char *data, size_t len, bool uppercase = false);
+
 void replace_all(std::string &s, std::string_view from, std::string_view to);
 
 std::string calculate_files_checksum(const fs::path &path);

--- a/test/src/generate_files.js
+++ b/test/src/generate_files.js
@@ -281,7 +281,7 @@ async function generate_server_dir(testinfo) {
         "- Removed Trovo (platform shut down).\n" +
         "- Bug fixes: NDI, recording, and multistreaming.\n" +
         "\n" +
-        "v1.21.6 - MacOS oriented release\n" +
+        "v1.21.6 - macOS oriented release\n" +
         "- Hardware encoding, transitions, bitrate display, and themes.\n" +
         "\n" +
         "v1.21.4\n" +

--- a/test/src/generate_files.js
+++ b/test/src/generate_files.js
@@ -271,33 +271,46 @@ async function generate_server_dir(testinfo) {
       fallbackVersion: testinfo.fallbackVersion,
       forceUpdate: false,
       details:
-        "Pretendlabs Desktop — Release Summary\n" +
-        "Covers all changes since v1.20.5.999-rc7-final-v3-actually-final\n\n" +
-        "This release upgrades the off-by-one count to zero and brings a broad set of refactors that nobody asked for.\n\n" +
-        "#features\n" +
-        "- New AI assistant that confidently writes O(n^3) sorting algorithms and calls them 'innovative'.\n" +
-        "- Added Quantum Debug Mode: when observed the bug disappears, when ignored it ships to production.\n" +
-        "- Introduced Schrodinger's Settings panel — your preferences are both saved and not saved until you reopen the app.\n" +
-        "- New Heisenberg Audio Mixer: you can know either the bitrate or the sample rate, never both.\n" +
-        "- Replaced legacy boolean with a tri-state truth value: true, false, and 'depends on the intern'.\n" +
-        "- Added '// TODO: handle this case' in 47 critical paths so you can finally sleep at night.\n" +
-        "- New Bikeshed Theme Editor lets your team argue for six weeks about whether the export button should be 4px or 5px tall.\n" +
-        "- Hot-loaded blockchain-AI-quantum-ML buzzword pipeline, currently powered by a single regex and prayer.\n\n" +
-        "#generalfixes\n" +
-        "- Fixed the off-by-one error introduced when fixing the previous off-by-one error.\n" +
-        "- Resolved a race condition in the race-condition handler; handlers now finish in roughly the order they were spawned.\n" +
-        "- Plugged 12 of the 14 known memory leaks; the other two have full benefits and their own parking spots.\n" +
-        "- Cache invalidation now correctly invalidates exactly the items that were not changed.\n" +
-        "- Tabs and spaces now coexist peacefully thanks to a new shared therapist process called clang-mediator.\n" +
-        "- Fixed undefined behavior on Tuesdays. Wednesdays remain implementation-defined.\n" +
-        "- Replaced 200 lines of 'we will refactor this later' with a single 800-line method called doTheThing().\n" +
-        "- The build is no longer reproducible, but it is reproducibly unreproducible, which we are counting as a win.\n\n" +
-        "#hotfixes\n" +
-        "- Reverted the revert that reverted the original revert; net change: a confused git history and one new co-author.\n" +
-        "- Fixed a NullPointerException that the comment directly above it explicitly said could never happen.\n" +
-        "- Patched a stack overflow in the recursion documentation; see the recursion documentation for details.\n" +
-        "- Hardcoded the build date so it is no longer a Heisenbug.\n\n" +
-        "Build date: roughly Tuesday-ish.",
+        "Streamlabs Desktop — What's New\n" +
+        "\n" +
+        "v1.21.8\n" +
+        "- Bug fixes: stock media library and translations.\n" +
+        "\n" +
+        "v1.21.7\n" +
+        "- New: Power-Ups in alerts, widgets, and recent events.\n" +
+        "- Removed Trovo (platform shut down).\n" +
+        "- Bug fixes: NDI, recording, and multistreaming.\n" +
+        "\n" +
+        "v1.21.6 - MacOS oriented release\n" +
+        "- Hardware encoding, transitions, bitrate display, and themes.\n" +
+        "\n" +
+        "v1.21.4\n" +
+        "- New: YouTube monetization toggle and stream labels for Kick.\n" +
+        "- Bug fixes: dual-output layout and Advanced recording.\n" +
+        "\n" +
+        "v1.21.3\n" +
+        "- Bug fixes: Twitch game selection and general stability.\n" +
+        "\n" +
+        "v1.21.2\n" +
+        "- Bug fixes: Patreon login, Go Live, overlays, and AI Highlighter.\n" +
+        "\n" +
+        "v1.21.1\n" +
+        "- Restored TikTok and X (Twitter) chat.\n" +
+        "- Bug fixes and more supported games.\n" +
+        "\n" +
+        "v1.21.0 — Major Release\n" +
+        "A major update built on OBS 31, focused on reliability and new ways to engage your audience.\n" +
+        "- Fewer crashes and freezes across streaming, recording, and media playback.\n" +
+        "- More reliable dual-output and vertical streaming.\n" +
+        "- Better encoder compatibility, including AV1 on supported setups.\n" +
+        "- macOS reliability improvements.\n" +
+        "- New AI hub featuring Game Pulse, Reactive Overlays, and a Streaming Agent.\n" +
+        "- Game Pulse: trigger alerts and effects from in-game events.\n" +
+        "- New Reactive Data Editor for dynamic overlays.\n" +
+        "- Your session now restores after a restart, plus a \"Manage on Web\" button on widgets.\n" +
+        "- Highlighter now supports F1 25, EA Sports FC 26, Black Ops 7, NBA 2K26, and Deadlock.\n" +
+        "- Added Patreon as a new platform.\n" +
+        "- Warns you when your video codec isn't supported for restreaming.",
     };
     fse.writeJsonSync(jsonfile, jsoncontent, { spaces: 2 });
   } else if (testinfo.version_details == "empty") {


### PR DESCRIPTION
Follow-up to #138. Same bug class, fixed at the source instead of at the call sites, plus the duplication #138 left behind.

## Background

#138 stopped the parallel-worker crash by replacing stream-based hex formatting with hand-rolled `hex_chars` loops in three places. That worked, but it patched each formatting site individually and copy-pasted the same loop three times.

## What this does

**1. Fixes the root cause.** `setup_locale()` now keeps the classic (C) numeric facets when it installs the `boost::locale` message catalog:

```cpp
real_locale = std::locale(real_locale, std::locale::classic(), std::locale::numeric);
```

`std` number formatting no longer inherits boost's numeric facets, so it stops reaching the MSVC CRT locale state that raced when download and checksum workers formatted numbers concurrently.

This is safe because **`boost::locale` is only ever used for `translate()`** in this codebase — I grepped every use site. Nothing depends on the numeric, collate, or ctype facets being boost's.

**2. Deduplicates.** The three copied hex loops collapse into one `to_hex()` in `utils.cc`, declared in `utils.hpp`. Case is preserved at every site:

| Site | Before | After | |
|---|---|---|---|
| `encimpl` | `0123456789ABCDEF` | `to_hex(&uc, 1, true)` | upper |
| `calculate_files_checksum` | `0123456789abcdef` | `to_hex(hash, LEN)` | lower |
| `handle_file_result` | `0123456789abcdef` | `to_hex(filter.digest, LEN)` | lower |

Lowercase matters — `handle_file_result` compares the digest against `expected_hash`.

**3. Covers what #138 missed.** `urlencode()` still round-tripped through `ostringstream`; it's now plain concatenation. `crash-reporter.cc` imbues `std::locale::classic()` on its two streams, since the handler runs on the faulting thread and cannot assume `setup_locale()` has run at all.

## Completeness audit

I swept `src/` for every remaining locale-sensitive path rather than assuming the three known sites were all of them:

| Site | Status |
|---|---|
| `crash-reporter.cc:83` `json_report` | imbued here |
| `crash-reporter.cc:174` `oss` | imbued here |
| `crash-reporter.cc:630,646` `std::hex` addresses | writes into `json_report` (passed at L102) — inherits the imbue |
| `crash-reporter.cc:727,775` `ss` | strings and chars only, no numeric formatting — not affected |
| `main.cc:983` `free_space_text` | already imbued by #138 |
| `printf`/`sprintf` family | all `%s`/`%d`/`%04i`/`%04x` — no `%f`, and printf applies no grouping without `%'d` |
| `lexical_cast`, `stod`, `strtod`, `atof` | none present — no locale-sensitive parsing anywhere |

Ordering is also safe: `setup_locale()` is the first statement in `wWinMain` (`main.cc:1683`), before any thread spawn (`main.cc:1740`, `update-client.cc:282`), so there is no race on installing the global locale itself.

One residual, verified unreachable: `std::locale::global()` can move the C locale, and the numeric-facet swap does not pin the C side. There is no float formatting or parsing in this codebase, so nothing can observe it. Worth a `setlocale(LC_NUMERIC, "C")` if that ever changes.

## Testing

Second commit swaps the placeholder text in `test/src/generate_files.js` for real Streamlabs Desktop release notes, so the release-notes panel can be screenshotted with representative content. Test fixture only, no production impact.

Not built locally — leaving that to CI per repo convention. `utils.hpp` verified clean against clang-format 19.1.5 (`.cc` files aren't gated by the format check).
